### PR TITLE
Metrics Website Home Page

### DIFF
--- a/app/site/index.liquid
+++ b/app/site/index.liquid
@@ -47,7 +47,7 @@ layout: base
                     </h2>
                 </div>
                 <div class="usa-card__body">
-                    <p> View Metrics on our 5+ Repositories </p>
+                    <p> View Metrics on our {{projects.length}}+ Repositories </p>
                 </div>
             </div>
         </li>


### PR DESCRIPTION
## module-name: Created Metrics Website Home Page

## Problem

Currently, the home/landing page for the website is blank.

## Solution

Home Page now includes a description of the website and category cards that redirect the user to a list of GitHub organization/projects. 

Any suggestions to improve the copy are welcomed!!!

## Result
<img width="1330" alt="Screen Shot 2023-11-16 at 9 01 28 AM" src="https://github.com/DSACMS/metrics/assets/29980737/de8b757e-5bcf-4fc2-9b31-48b3c391a6f6">

(Regarding the category cards, this does not follow the proposed Figma design. I was running into issues with setting icon size/styling using the 11ty Lucide plugin. Will make an issue to the upstream repo and revisit styling in version 1.)

## Test Plan
Manually viewed pages.