### PR TITLE
Added Organization Header to Projects Page

### DIFF
--- a/app/.eleventy.js
+++ b/app/.eleventy.js
@@ -57,6 +57,10 @@ module.exports = function (eleventyConfig) {
     return array.find(item => item["name"] === value);
   });
 
+  eleventyConfig.addFilter("findProjectsInOrg", function(array, value) {
+    return array.filter(item => item["owner"] === value);
+  });
+
   // Create a collection of items without permalinks so that we can reference them
   // in a separate shortcode to pull in partial content directly
   eleventyConfig.addCollection("partials", (collectionApi) =>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -12,8 +12,8 @@ layout: base
   </div>
 
   <div class="report_container">
+    <h2>Repo Stats</h2>
     {% if project %}
-      <h2>Repo Stats</h2>
       <div class="github-information">
         <div class="stat-container" id="stars">
           <div class="stars-heading">

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -5,8 +5,21 @@ layout: base
       <p>
         The Centers for Medicare and Medicaid Services develops and supports many open-source projects found in our various GitHub Organizations.
       </p>
-      <ul class="usa-card-group flex-align-stretch">
-        {% for repo in projects %}
+
+      {% for org in organizations %}
+        <div class="report_heading">
+          <h2>
+            {{ org.name }}
+            <img
+              src="{{org.avatar_url}}"
+              alt="Organization Avatar"
+              width="20" />
+          </h2>
+        </div>
+
+      <ul class="usa-card-group flex-align-stretch">        
+        {% assign orgProjects = projects | findProjectsInOrg: org.name %}
+        {% for repo in orgProjects %}
           <li class="usa-card project-card tablet:grid-col-12">
             <div class="usa-card__container">
               <div class="usa-card__header">
@@ -58,4 +71,5 @@ layout: base
           </li>
         {% endfor %}
       </ul>
+    {% endfor %}
     </div>


### PR DESCRIPTION
## Added Organization Header to Projects Page

## Problem

Currently, the projects page lists all the projects without indicating which organization these projects are under.

## Solution

Added a header for organization that shows a list of projects under that organization for MVP. 
(Will probably replace this with a filter for organization in the future.)

Minor edit of moving placement of "Repo Stats" header.

## Result
<img width="1369" alt="Screen Shot 2023-11-20 at 10 27 04 AM" src="https://github.com/DSACMS/metrics/assets/29980737/e2be4b71-89eb-4ec8-99f0-3ca574b91811">



## Test Plan
Manually viewed pages.
