### PR TITLE
Removed vite plugin due to passthrough copy bug

### DIFF
--- a/app/.eleventy.js
+++ b/app/.eleventy.js
@@ -1,7 +1,6 @@
 const fs = require("fs")
 const path = require("path")
 const Image = require("@11ty/eleventy-img")
-const EleventyVitePlugin = require("@11ty/eleventy-plugin-vite")
 const lucideIcons = require("@grimlink/eleventy-plugin-lucide-icons");
 const { baseurl } = require("./site/_data/site");
 require("dotenv").config()
@@ -76,10 +75,9 @@ module.exports = function (eleventyConfig) {
     "src/css": "css",
     "site/_graphs": "assets/img/graphs",
     "node_modules/@uswds/uswds/dist/img": "assets/img",
-  })
+  });
 
   eleventyConfig.setLiquidOptions({ outputEscape: "escape" })
-  eleventyConfig.addPlugin(EleventyVitePlugin)
   eleventyConfig.addPlugin(lucideIcons, {
     "class": "custom-class",
     "width": 17,
@@ -99,6 +97,6 @@ module.exports = function (eleventyConfig) {
     },
     templateFormats: ["html", "md", "liquid", "11ty.js"],
     passthroughFileCopy: true,
-    pathPrefix,
+    pathPrefix
   }
 }


### PR DESCRIPTION
## Removed vite plugin due to passthrough copy bug

## Problem

We currently use the Vite Plugin to build our production website. When building for production, all files under the `addPassthroughCopy` are not included in the output folder. It seems this is a common issue and is currently not resolved in the upstream: https://github.com/11ty/eleventy-plugin-vite/issues/42

## Solution

Remove the Vite Plugin from the project and `addPassthroughCopy` works as intended. Research and consider other build tools to use.