### PR TITLE
Updated repo report template to reflect correct permalinks and graph paths

### DIFF
--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -1,7 +1,7 @@
 ---
 layout: repo-report
 title: Open Source at CMS Metrics Report for {repo_name} | REPORT-{date_stamp}
-permalink: /{repo_owner}/{repo_name}
+permalink: /{repo_owner}/{repo_name}/
 
 org: {repo_owner}
 repo: {repo_name}
@@ -101,12 +101,12 @@ date_stampLastWeek: {date_stamp}
   <div class="row">
     <!--- Issues/PRs Status Breakdown Graph -->
     <figure>
-      <embed type="image/svg+xml" src="../assets/img/graphs/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" />
+      <embed type="image/svg+xml" src="../../assets/img/graphs/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" />
     </figure>
     <!--- Contributor Activity Line Graph -->
     <h3>Commits by Month</h3>
     <figure>
-      <embed type="image/svg+xml" src="../assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" />
+      <embed type="image/svg+xml" src="../../assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" />
     </figure>
   </div>
 </div>


### PR DESCRIPTION
## Updated repo report template to reflect correct permalinks and graph paths

## Problem

Originally, the report permalink was structured as `/$REPO_OWNER/$REPO_NAME`. The missing trailing slash caused 11ty to not generate the project report pages as html files. As a result, the project report page for a repo would not display in the production build.

## Solution

- Permalinks have been changed to `/$REPO_OWNER/$REPO_NAME/` which will create a new directory and index.html for each project in the root output directory.
- Due to the change above, adjusted graph paths.

@IsaacMilarky, please make these changes on the backend!