### PR TITLE
Fix Incorrect Hover-Text in Pygals Gauge Graphs

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -109,8 +109,8 @@ def generate_solid_gauge_issue_graph(oss_entity):
                      {'value': open_pr_percent * 100, 'max_value': 100}])
     issues_gauge.add(
         'Closed and Merged Pull Requests', [
-            {'value': merged_pr_percent * 100, 'max_value': 100},
-            {'value': closed_pr_percent * 100, 'max_value': 100}])
+            {'label': "Merged Pull Requests",'value': merged_pr_percent * 100, 'max_value': 100},
+            {'label': "Closed Pull Requests", 'value': closed_pr_percent * 100, 'max_value': 100}])
 
     write_repo_chart_to_file(oss_entity, issues_gauge, "issue_gauge")
 


### PR DESCRIPTION

## Fix Incorrect Hover-Text in Pygals Gauge Graphs

## Problem

The text that appears when hovering over portions of a solid gauge graph generated by the update script was incorrect previously. Previously, the text was the title of the graph regardless of the selected portion of the graph.

## Solution

I have added respective labels to the closed/merged portions of the closed and merged pull request solid gauge graph. The merged section now displayed the text "Merged Pull Requests" when hovered over instead of the title of the graph only. The closed pull request section now displays the text "Closed Pull Requests" when hovered over.

## Result

Now the generated solid gauge graphs have the proper labels:
<img width="1473" alt="Screen Shot 2023-11-27 at 3 46 53 PM" src="https://github.com/DSACMS/metrics/assets/24639268/a7c137dc-aca4-43b7-b2ac-7adf693fcda3">


