### PR TITLE
Fix Syntax of Github Workflow to Update Data

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -35,7 +35,6 @@ jobs:
           git add -A
           timestamp=$(date -u)
           git commit -m "update data: ${timestamp}" || exit 0
-          git push
       - name: Push to main
         uses: CasperWA/push-protected@v2
         with:

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -35,8 +35,8 @@ jobs:
           git add -A
           timestamp=$(date -u)
           git commit -m "update data: ${timestamp}" || exit 0
-      - name: Push to main
+      - name: Push to ${{ github.ref_name }}
         uses: CasperWA/push-protected@v2
         with:
           token: ${{ secrets.METRICS_GITHUB_TOKEN }}
-          branch: main
+          branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Fix Syntax of Github Workflow to Update Data

## Problem

Branch permissions prevented the update script from pushing to main.

## Solution

Fix the syntax of the update GH workflow to only update the branch that triggered the workflow. Also make sure that the only thing that pushes to the requested branch has the proper branch permissions. 
