### PR TITLE
Minor Frontend Additions for V1 Preparation

### DIFF
--- a/app/.eleventy.js
+++ b/app/.eleventy.js
@@ -1,9 +1,5 @@
-const fs = require("fs")
-const path = require("path")
 const Image = require("@11ty/eleventy-img")
 const lucideIcons = require("@grimlink/eleventy-plugin-lucide-icons");
-const { baseurl } = require("./site/_data/site");
-require("dotenv").config()
 
 async function resizeImage(src, sizes, outputFormat = "png") {
   const stats = await Image(src, {

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,8 @@
     "build:clean": "rm -rf dist",
     "build:rollup": "rollup --config rollup.config.mjs --bundleConfigAsCjs",
     "build:postcss": "postcss ./src/css -d ./site/_includes/css",
-    "build:eleventy": "eleventy"
+    "build:eleventy": "eleventy",
+    "build:deploy": "cd dist && touch .nojekyll"
   },
   "keywords": [],
   "author": "",

--- a/app/site/_includes/metadata.liquid
+++ b/app/site/_includes/metadata.liquid
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<base href="{{ site.url }}" />
 
 <title>{{ title | default: page.title | default: site.title }}</title>
 <meta name="description" content="{{ description | default: page.description | default: site.description }}">
@@ -13,13 +14,13 @@
 <meta property="og:description" content="{{ description | default: page.description | default: site.description }}">
 <meta property="og:type" content="{{ site.type }}">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-<meta property="og:image" content="{{ site.url }}/img/social.png">
+<meta property="og:image" content="{{ site.url }}/assets/img/social.png">
 <meta property="og:image:alt" content="{{ title | default: page.title | default: site.title }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 
-<link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}{% resizeImage './src/img/icon.png', '16x16' %}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}{% resizeImage './src/img/icon.png', '32x32' %}">
-<link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}{% resizeImage './src/img/icon.png', '180x180' %}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}/assets{% resizeImage './src/img/icon.png', '16x16' %}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}/assets{% resizeImage './src/img/icon.png', '32x32' %}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}/assets{% resizeImage './src/img/icon.png', '180x180' %}">
 <link rel="manifest" href="{{ site.url }}/manifest.json">
 <meta name="theme-color" content="#ffffff">

--- a/app/site/manifest.json.liquid
+++ b/app/site/manifest.json.liquid
@@ -1,0 +1,25 @@
+---
+layout: null
+permalink: /manifest.json
+sizes:
+  - 48x48
+  - 192x192
+  - 512x512
+eleventyExcludeFromCollections: true
+---
+{
+  "name": "{{ site.title }}",
+  "short_name": "{{ site.title }}",
+  "icons": [
+    {% for size in sizes %}
+    {
+      "sizes": "{{ size }}",
+      "src": "/assets{% resizeImage './src/img/icon.png', size %}",
+      "type": "image/png"
+    }{%- if not loop.last -%},{%- endif -%}
+    {% endfor %}
+  ],
+  "theme_color": "#b3ddf2",
+  "background_color": "#b3ddf2",
+  "display": "standalone"
+}

--- a/app/site/robots.txt.liquid
+++ b/app/site/robots.txt.liquid
@@ -1,5 +1,5 @@
 ---
-permalink: "./robots.txt"
+permalink: "/robots.txt"
 layout: null
 eleventyExcludeFromCollections: true
 ---

--- a/app/site/robots.txt.liquid
+++ b/app/site/robots.txt.liquid
@@ -1,0 +1,12 @@
+---
+permalink: "./robots.txt"
+layout: null
+eleventyExcludeFromCollections: true
+---
+{% if site.robots %}
+User-agent: *
+Disallow:
+{% else %}
+User-agent: *
+Disallow: /
+{% endif %}


### PR DESCRIPTION
## Minor Frontend Additions for V1 Preparation

## Problem

- [.github project report link](https://dsacms.github.io/metrics/DSACMS/.github/) is broken due Jekyll blocking .github folder from being included in the deploy (Jekyll ignores file names that start with "." and other special characters)
- Missing `robots.txt`. As a good practice, our frontend should have this file for SEO purposes.
- Missing `manifest.json`.

## Solution

- Added a .nojekyll file to bypass
- Created a robots.txt file that allows all web crawlers access to all content.
- Created a manifest.json + minor updates to website metadata. Creates images that are used as website's favicon. Used the DSAC logo as icon for now but we can change this in the future.
- Remove unused packages

## Result
- [.github project report link](https://dsacms.github.io/metrics/DSACMS/.github/) displays project report
- 
Website icons changes from this:
<img width="210" alt="Screen Shot 2023-12-04 at 10 29 48 AM" src="https://github.com/DSACMS/metrics/assets/29980737/a16f8aba-6647-4c2f-b342-be5949099543">

.... to this:
<img width="229" alt="Screen Shot 2023-12-04 at 10 30 04 AM" src="https://github.com/DSACMS/metrics/assets/29980737/2d8c57c7-74ae-434e-a765-bdcd9957a9dd">

## Test Plan
Manually viewed webpages.