### PR TITLE
Create GitHub Workflow to Run Custom Checks on PR Creation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   run-pylint:
-    permissions: read-all
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - run: pylint --disable R --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+      - run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/* || echo "Pylint Errors detected above!"
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
       - run: pip install -r requirements.txt
       - name: GitHub Action for pylint
         uses: cclauss/GitHub-Action-for-pylint@0.7.0
-        args: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+        run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-          PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')"" scripts/*)
+          PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*)
           echo "PYLINT_REPORT=$PYLINT_REPORT" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - uses: cclauss/GitHub-Action-for-pylint@0.7.0
       - run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
             
       - uses: LouisBrunner/checks-action@v1.6.1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/* || echo "Pylint Errors detected above!"
+      - run: |
+        echo "PYLINT_REPORT=$(pylint --init-hook='import sys; sys.path.append(\'scripts/\')' scripts/* || echo 'Pylint Errors detected above!')" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()
@@ -28,4 +29,4 @@ jobs:
           name: Test XYZ
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{ steps.test.outputs.summary }}"}
+            {"summary":"${{ steps.test.outputs.summary }}   ${{ env.PYLINT_REPORT}}"}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,8 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-        echo "PYLINT_REPORT=$(pylint --init-hook='import sys; sys.path.append(\'scripts/\')' scripts/* || echo 'Pylint Errors detected above!')" >> $GITHUB_ENV
+      SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')""
+      echo "PYLINT_REPORT=$(pylint --init-hook='$SCRIPT_INIT_HOOK' scripts/* || echo 'Pylint Errors detected above!')"
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,7 @@ on: [push]
 
 jobs:
   run-pylint:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+      - run: pylint --disable R --init-hook="import sys; sys.path.append('scripts/')" scripts/*
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,32 @@
+name: "run-linting-checks"
+on: [push]
+
+jobs:
+  run-pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # update stats
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - run: pip install -r requirements.txt
+      - name: GitHub Action for pylint
+        uses: cclauss/GitHub-Action-for-pylint@0.7.0
+        args: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+            
+      - uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Test XYZ
+          conclusion: ${{ job.status }}
+          output: |
+            {"summary":"${{ steps.test.outputs.summary }}"}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,4 +32,6 @@ jobs:
           name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "${{ env.PYLINT_REPORT }}"}
+            {"summary":"${{job.status}}" , "text_description": "Job has finished"}
+          annotations: |
+            ${{ env.PYLINT_REPORT }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,8 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-        SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
-        echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
+          SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
+          echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,7 @@
 name: "run-linting-checks"
-on: [push]
+on:
+  pull_request:
+    branches: [main, dev]
 
 jobs:
   run-pylint:
@@ -29,7 +31,7 @@ jobs:
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Run Pylint
+          name: Pylint Report
           conclusion: ${{ job.status }}
           output: |
             {"summary":"${{job.status}}" , "text_description": "Job has finished "}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-          (exit 0); PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*)
+          PYLINT_REPORT=$(./run_pylint.sh)
           echo "PYLINT_REPORT=$PYLINT_REPORT" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
@@ -30,4 +30,4 @@ jobs:
           name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "$PYLINT_REPORT"}
+            {"summary":"${{job.status}}" , "text_description": "${{ env.PYLINT_REPORT }}"}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,8 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-      SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')""
-      echo "PYLINT_REPORT=$(pylint --init-hook='$SCRIPT_INIT_HOOK' scripts/* || echo 'Pylint Errors detected above!')"
+      SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
+      echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,6 @@ jobs:
           name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "Job has finished \n ${{ env.PYLINT_REPORT }}"}
+            {"summary":"${{job.status}}" , "text_description": "Job has finished "}
           annotations: |
             ${{ env.PYLINT_REPORT }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,8 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-      SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
-      echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
+        SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
+        echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,8 @@ jobs:
       - run: |
           SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
           echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
+
+          echo $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()
@@ -30,4 +32,4 @@ jobs:
           name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "${{ env.PYLINT_REPORT}}"}
+            {"summary":"${{job.status}}" , "text_description": "$PYLINT_REPORT"}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,9 @@ jobs:
       - run: pip install -r requirements.txt
       - run: |
           PYLINT_REPORT=$(./run_pylint.sh)
-          echo "PYLINT_REPORT=$PYLINT_REPORT" >> $GITHUB_ENV
+          echo "PYLINT_REPORT<<EOF" >> $GITHUB_ENV
+          echo "$PYLINT_REPORT" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,6 @@ jobs:
           name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "Job has finished"}
+            {"summary":"${{job.status}}" , "text_description": "Job has finished \n ${{ env.PYLINT_REPORT }}"}
           annotations: |
             ${{ env.PYLINT_REPORT }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,9 +18,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - name: GitHub Action for pylint
-        uses: cclauss/GitHub-Action-for-pylint@0.7.0
-        run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+      - uses: cclauss/GitHub-Action-for-pylint@0.7.0
+      - run: pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-          PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*)
+          (exit 0); PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*)
           echo "PYLINT_REPORT=$PYLINT_REPORT" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,7 @@
 name: "run-linting-checks"
-on: [push]
+on:
+  pull_request:
+    branches: [main, dev]
 
 jobs:
   run-pylint:
@@ -38,6 +40,6 @@ jobs:
           status: completed
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{job.status}}" , "text_description": "Job has finished "}
+            {"summary":"Pylint Report Generation ran with status: ${{job.status}}" , "text_description": "Pylint Issues are listed below."}
           annotations: |
             ${{ env.PYLINT_REPORT }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,13 +1,17 @@
 name: "run-linting-checks"
-on:
-  pull_request:
-    branches: [main, dev]
+on: [push]
 
 jobs:
   run-pylint:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
+      - uses: LouisBrunner/checks-action@v1.6.1
+        id: init
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Pylint Report
+          status: in_progress
       - uses: actions/checkout@v4
       # update stats
       - uses: actions/setup-python@v4
@@ -28,10 +32,10 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
-        if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Pylint Report
+          check_id: ${{ steps.init.outputs.check_id }}
+          status: completed
           conclusion: ${{ job.status }}
           output: |
             {"summary":"${{job.status}}" , "text_description": "Job has finished "}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,6 @@ jobs:
       - run: |
           SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
           echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
-
-          echo $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,8 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: |
-          SCRIPT_INIT_HOOK="import sys; sys.path.append('scripts/')"
-          echo "PYLINT_REPORT=$(pylint --init-hook=$SCRIPT_INIT_HOOK scripts/*)" >> $GITHUB_ENV
+          PYLINT_REPORT=$(pylint --init-hook="import sys; sys.path.append('scripts/')"" scripts/*)
+          echo "PYLINT_REPORT=$PYLINT_REPORT" >> $GITHUB_ENV
             
       - uses: LouisBrunner/checks-action@v1.6.1
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Test XYZ
+          name: Run Pylint
           conclusion: ${{ job.status }}
           output: |
-            {"summary":"${{ steps.test.outputs.summary }}   ${{ env.PYLINT_REPORT}}"}
+            {"summary":"${{job.status}}" , "text_description": "${{ env.PYLINT_REPORT}}"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pygal
 pandas
 pytest
+pylint

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+pylint --output-format=json --init-hook="import sys; sys.path.append('scripts/')" scripts/*
 exit 0

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-pylint --output-format=json --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+#pylint --output-format=json --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+python scripts/run_pylint.py
 exit 0

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+pylint --init-hook="import sys; sys.path.append('scripts/')" scripts/*
+exit 0

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -1,0 +1,3 @@
+from tests.metrics_tests import run_pylint
+
+run_pylint()

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -20,13 +20,13 @@ def run_pylint():
             item['annotation_level'] = 'warning'
         item['end_line'] = item.pop('endLine')
         if item['end_line'] is None:
-            item['end_line'] = -1
+            item['end_line'] = item['line']
 
         item['start_line'] = item.pop('line')
         item['start_column'] = item.pop('column')
         item['end_column'] = item.pop('endColumn')
         if item['end_column'] is None:
-            item['end_column'] = -1
+            item['end_column'] = item['column']
         item['title'] = item.pop('symbol')
 
         item.pop('module')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -13,7 +13,15 @@ def run_pylint():
 
     for item in pylint_list:
         item['annotation_level'] = item.pop('type')
+
+        if item['annotation_level'] == "convention":
+            item['annotation_level'] = 'notice'
+        elif item['annotation_level'] == "refactor":
+            item['annotation_level'] = 'warning'
         item['end_line'] = item.pop('endLine')
+        if item['end_line'] is None:
+            item.pop('end_line')
+
         item['start_line'] = item.pop('line')
     
     print(json.dumps(pylint_list))

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -1,5 +1,19 @@
 import pytest
+import json
 from metricsLib import metrics_data_structures
+import subprocess
 
 def test_base_metric():
     raise NotImplementedError
+
+def run_pylint():
+    pylint_out = subprocess.run(['pylint', '--output-format=json', "--init-hook=\"import sys; sys.path.append('scripts/')\"", "scripts/*"],stdout = subprocess.PIPE,check=False)
+
+    pylint_list = json.loads(pylint_out.stdout)
+
+    for item in pylint_list:
+        item['annotation_level'] = item.pop('type')
+        item['end_line'] = item.pop('endLine')
+        item['start_line'] = item.pop('line')
+    
+    print(json.dumps(pylint_list))

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -7,17 +7,24 @@ def test_base_metric():
     raise NotImplementedError
 
 def run_pylint():
+    #Run pylint command and parse json
     pylint_out = subprocess.run(['pylint', '--output-format=json', "--init-hook=\"import sys; sys.path.append('scripts/')\"", "scripts/*"],stdout = subprocess.PIPE,check=False)
 
     pylint_list = json.loads(pylint_out.stdout)
 
+
+    #Parse pylint format into GitHub Checks Annotation format
     for item in pylint_list:
+        #Rename error type to annotation_level
         item['annotation_level'] = item.pop('type')
 
+        #translate pylint terms to github terms
         if item['annotation_level'] == "convention":
             item['annotation_level'] = 'notice'
         elif item['annotation_level'] == "refactor":
             item['annotation_level'] = 'warning'
+        
+        #if end fields are empty, make them the same as the start
         item['end_line'] = item.pop('endLine')
         if item['end_line'] is None:
             item['end_line'] = item['line']
@@ -29,6 +36,7 @@ def run_pylint():
             item['end_column'] = item['start_column']
         item['title'] = item.pop('symbol')
 
+        #Don't include columns if annotation spans multiple lines
         if item['start_line'] != item['end_line']:
             item.pop('start_column')
             item.pop('end_column')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -26,7 +26,7 @@ def run_pylint():
         item['start_column'] = item.pop('column')
         item['end_column'] = item.pop('endColumn')
         if item['end_column'] is None:
-            item.pop('end_column')
+            item['end_column'] = -1
         item['title'] = item.pop('symbol')
 
         item.pop('module')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -26,7 +26,7 @@ def run_pylint():
         item['start_column'] = item.pop('column')
         item['end_column'] = item.pop('endColumn')
         if item['end_column'] is None:
-            item['end_column'] = item['column']
+            item['end_column'] = item['start_column']
         item['title'] = item.pop('symbol')
 
         item.pop('module')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -29,6 +29,9 @@ def run_pylint():
             item['end_column'] = item['start_column']
         item['title'] = item.pop('symbol')
 
+        if item['start_line'] != item['end_line']:
+            item.pop('start_column')
+            item.pop('end_column')
         item.pop('module')
         item.pop('obj')
         item.pop('message-id')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -20,7 +20,7 @@ def run_pylint():
             item['annotation_level'] = 'warning'
         item['end_line'] = item.pop('endLine')
         if item['end_line'] is None:
-            item.pop('end_line')
+            item['end_line'] = -1
 
         item['start_line'] = item.pop('line')
         item['start_column'] = item.pop('column')

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -28,5 +28,9 @@ def run_pylint():
         if item['end_column'] is None:
             item.pop('end_column')
         item['title'] = item.pop('symbol')
+
+        item.pop('module')
+        item.pop('obj')
+        item.pop('message-id')
     
     print(json.dumps(pylint_list, indent=2))

--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -23,5 +23,10 @@ def run_pylint():
             item.pop('end_line')
 
         item['start_line'] = item.pop('line')
+        item['start_column'] = item.pop('column')
+        item['end_column'] = item.pop('endColumn')
+        if item['end_column'] is None:
+            item.pop('end_column')
+        item['title'] = item.pop('symbol')
     
-    print(json.dumps(pylint_list))
+    print(json.dumps(pylint_list, indent=2))


### PR DESCRIPTION
## Create GitHub Workflow to Run Custom Checks on PR Creation

## Problem

Before, linting and other checking wasn't done automatically when a pull-request was created.

## Solution

When a pull request is created, a github action is triggered to run a set of checks on the corresponding git branch. The first of which, called `run-pylint`, runs pylint, stores the resulting json in a variable, and passes that variable to some check annotations. This job basically adds pylint annotations to a branch automatically when a PR is opened. 

NOTE: I have tested this with the `on: push` trigger since It's better to test that way. According to https://github.com/LouisBrunner/checks-action/issues/12 the action should behave the same when used with the `on: pull_request` trigger.

Result:
<img width="929" alt="Screen Shot 2023-12-05 at 2 45 47 PM" src="https://github.com/DSACMS/metrics/assets/24639268/27ff7e95-a73a-48ae-963e-b42a42582f8d">
