### PR TITLE
Add Pylint Annotation Limit

### DIFF
--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -44,4 +44,6 @@ def run_pylint():
         item.pop('obj')
         item.pop('message-id')
     
-    print(json.dumps(pylint_list, indent=2))
+    to_return = json.dumps(pylint_list, indent=2)
+    #Print max of 50 terms since thats the max for GitHub
+    print(to_return[:50])


### PR DESCRIPTION
## Add Pylint Annotation Limit

## Problem

The annotations that GitHub lets you create via GitHub Checks can only hold a maximum of 50 values.

## Solution

Limit the amount of PyLint outputs to 50 at maximum.
