### PR TITLE
Patch Pylint Check to Return a Max of 50 Annotations.

### DIFF
--- a/scripts/tests/metrics_tests.py
+++ b/scripts/tests/metrics_tests.py
@@ -44,6 +44,6 @@ def run_pylint():
         item.pop('obj')
         item.pop('message-id')
     
-    to_return = json.dumps(pylint_list, indent=2)
+    to_return = pylint_list[:50]#json.dumps(pylint_list, indent=2)
     #Print max of 50 terms since thats the max for GitHub
-    print(to_return[:50])
+    print(json.dumps(to_return, indent=2))


### PR DESCRIPTION
## Patch Pylint Check to Return a Max of 50 Annotations.

## Problem

GitHub's check annotations can only handle a max of 50 in one check.

## Solution

Added a limit of 50 to the annotation generation.

