### PR TITLE
Fix for Path Bug

### DIFF
--- a/app/site/organizations.liquid
+++ b/app/site/organizations.liquid
@@ -9,7 +9,7 @@ layout: base
         <div class="usa-card__container">
           <div class="usa-card__header">
             <h2 class="usa-card__heading">
-              <a href="../{{org.name}}/" class="text-no-underline">{{ org.name }}</a>
+              <a href="{{ site.baseurl }}/{{ org.name }}/" class="text-no-underline">{{ org.name }}</a>
             </h2>
           </div>
           <div class="usa-card__media" style="display: flex; justify-content: center;">

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -26,7 +26,7 @@ layout: base
           <div class="usa-card__container">
             <div class="usa-card__header">
               <h2 class="usa-card__heading">
-                <a href="../{{repo.owner}}/{{repo.name}}/" class="text-no-underline">{{ repo.name }}</a>
+                <a href="{{ site.baseurl }}/{{ repo.owner }}/{{ repo.name }}/" class="text-no-underline">{{ repo.name }}</a>
               </h2>
             </div>
             <div class="usa-card__body">


### PR DESCRIPTION
## Fix for Path Bug

## Problem

Adding the 2 additional organizations + its projects (#77) caused broken links for all organization report pages and project report pages in [list of orgs page](https://dsacms.github.io/metrics/organizations) and [list of projects page](https://dsacms.github.io/metrics/projects). This was due to "/metrics" being missing in the url path.

## Solution

Instead of obtaining the reports by using the file location in the project directory, href now uses`site.baseurl`as part of the href value since this variable includes the path prefix.

## Result

Links are fixed, successfully redirecting to organization report pages and project report pages.

## Test Plan

Verified changes manually.
