### PR TITLE
Fix graph paths for Org & Repo Report

### DIFF
--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -107,7 +107,7 @@ date_stampLastWeek: {date_stamp}
   <div class="row">
     <!--- Issues/PRs Status Breakdown Graph -->
     <figure>
-      <embed type="image/svg+xml" src="../assets/img/graphs/{repo_owner}/{repo_owner}_issue_gauge.svg" />
+      <embed type="image/svg+xml" src="{{ "/assets/img/graphs/{repo_owner}/{repo_owner}_issue_gauge.svg" | url }}" />
     </figure>
   </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -101,12 +101,12 @@ date_stampLastWeek: {date_stamp}
   <div class="row">
     <!--- Issues/PRs Status Breakdown Graph -->
     <figure>
-      <embed type="image/svg+xml" src="../../assets/img/graphs/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" />
+      <embed type="image/svg+xml" src="{{ "/assets/img/graphs/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" | url }}" />
     </figure>
     <!--- Contributor Activity Line Graph -->
     <h3>Commits by Month</h3>
     <figure>
-      <embed type="image/svg+xml" src="../../assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" />
+      <embed type="image/svg+xml" src="{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}" />
     </figure>
   </div>
 </div>


### PR DESCRIPTION
## Fix graph paths for Org & Repo Report

## Problem

In the Org & Repo Report pages, there is an error with retrieving graphs due to incorrect path.

## Solution

Updated path to include "/metrics" prefix using `| url`.

## Result
All graphs are displayed in report pages.

## Test Plan

Verified changes manually.
