### PR TITLE
Minor UI Fixes for V1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ app/node_modules
 app/dist
 app/.env
 app/site/img/*
+app/site/_includes
 !app/site/img/.keep
 .vscode/
 scripts/metricsLib/__pycache__

--- a/app/site/_includes/banner.liquid
+++ b/app/site/_includes/banner.liquid
@@ -1,5 +1,15 @@
-<div class="bg-orange text-white text-center font-sans-lg">
-  <div class="grid-container padding-2">Work in progress. Not an official government site.</div>
+<div class="bg-primary-lighter text-ink text-center">
+  <div class="grid-container padding-1"> 
+    <p class="usa-banner__header-text">Work in progress. We welcome questions and suggestions — 
+      <a
+      class="usa-link usa-link--external"
+      rel="noreferrer"
+      target="_blank"
+      href="https://github.com/DSACMS/metrics/issues/new"
+      >give us feedback.</a
+    >
+    </p>
+  </div>
 </div>
 <section
   class="usa-banner"

--- a/app/site/_layouts/org-report.liquid
+++ b/app/site/_layouts/org-report.liquid
@@ -23,7 +23,6 @@ layout: base
         <div class="stat-container" id="projects">
           <div class="projects-heading">
             <h4>
-              Repositories
               <span>
                 <svg
                   class="usa-icon"
@@ -33,6 +32,7 @@ layout: base
                   {% lucide "folder-git-2" %}
                 </svg>
               </span>
+              Repositories
             </h4>
           </div>
           <p>{{ organization.repo_count }}</p>
@@ -40,7 +40,6 @@ layout: base
         <div class="stat-container" id="followers">
           <div class="followers-heading">
             <h4>
-              Followers
               <span>
                 <svg
                   class="usa-icon"
@@ -50,6 +49,7 @@ layout: base
                   {% lucide "users-2" %}
                 </svg>
               </span>
+              Followers
             </h4>
           </div>
           <p>{{ organization.followers_count }}</p>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -18,7 +18,6 @@ layout: base
         <div class="stat-container" id="stars">
           <div class="stars-heading">
             <h4>
-              Stars
               <span>
                 <svg
                   class="usa-icon"
@@ -28,6 +27,7 @@ layout: base
                   {% lucide "star" %}
                 </svg>
               </span>
+              Stars
             </h4>
           </div>
           <p>{{ project.stargazers_count }}</p>
@@ -35,7 +35,6 @@ layout: base
         <div class="stat-container" id="forks">
           <div class="forks-heading">
             <h4>
-              Forks
               <span>
                 <svg
                   class="usa-icon"
@@ -45,6 +44,7 @@ layout: base
                   {% lucide "git-fork" %}
                 </svg>
               </span>
+              Forks
             </h4>
           </div>
           <p>{{ project.forks_count }}</p>
@@ -52,7 +52,6 @@ layout: base
         <div class="stat-container" id="issues">
           <div class="issues-heading">
             <h4>
-              Issues
               <span>
                 <svg
                   class="usa-icon"
@@ -62,6 +61,7 @@ layout: base
                   {% lucide "circle-dot" %}
                 </svg>
               </span>
+              Issues
             </h4>
           </div>
           <p>{{ project.issues_count }}</p>
@@ -69,7 +69,6 @@ layout: base
         <div class="stat-container" id="watchers">
           <div class="watchers-heading">
             <h4>
-              Watchers
               <span>
                 <svg
                   class="usa-icon"
@@ -79,6 +78,7 @@ layout: base
                   {% lucide "eye" %}
                 </svg>
               </span>
+              Watchers
             </h4>
           </div>
           <p>{{ project.watchers_count }}</p>
@@ -86,7 +86,6 @@ layout: base
         <div class="stat-container" id="pull-requests">
           <div class="pull-requests-heading">
             <h4>
-              Pull Requests
               <span>
                 <svg
                   class="usa-icon"
@@ -96,6 +95,7 @@ layout: base
                   {% lucide "git-pull-request" %}
                 </svg>
               </span>
+              Pull Requests
             </h4>
           </div>
           <p>{{ project.pull_requests_count }}</p>

--- a/app/site/index.liquid
+++ b/app/site/index.liquid
@@ -20,7 +20,7 @@ layout: base
               >Organizations
               <span class="chevrons-right">
                 <svg class="usa-icon usa-icon--size-2" aria-hidden="true" focusable="false" role="img">
-                  <use xlink:href="/assets/img/sprite.svg#navigate_far_next"></use>
+                  <use xlink:href= {{ "/assets/img/sprite.svg#navigate_far_next" | url }}></use>
                 </svg>
               </span>
             </a>
@@ -43,7 +43,7 @@ layout: base
               >Projects
               <span class="chevrons-right">
                 <svg class="usa-icon usa-icon--size-2" aria-hidden="true" focusable="false" role="img">
-                  <use xlink:href="/assets/img/sprite.svg#navigate_far_next"></use>
+                  <use xlink:href={{ "/assets/img/sprite.svg#navigate_far_next" | url }} ></use>
                 </svg>
               </span>
             </a>

--- a/app/site/organizations.liquid
+++ b/app/site/organizations.liquid
@@ -36,7 +36,7 @@ layout: base
                 <title id="github-{{org.name}}-title"> Follower Count</title>
                 {% lucide "users-2" %}
               </svg>
-              <span> {{ org.stargazers_count }} </span>
+              <span> {{ org.followers_count }} </span>
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Minor UI Fixes

## Problem

Now that the website is updated with more organizations and projects, there were a couple of minor UI bugs that came up as a result.

## Solution

Fixes include:
- Updating "In Progress" banner to include feedback form + color change
- For GitHub stats (# of Repos, Followers, Stars, etc.) switched location of icons to the left of title
- Incorrect value used for Followers. Changed from `stargazers_count` to `followers_count`
- Updated URL of `navigate_far_next` icon to include path prefix. Now displaying
- Added `includes_` dir to .gitignore 

## Test Plan
Manually verified changes.
