### PR TITLE
Add GitHub Workflow to Auto-Merge `main` into `dev`

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,27 @@
+name: Merge main into dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dev:
+    permissions: write-all
+    name: update-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@users.noreply.github.com'
+          git checkout dev
+          git merge main
+          echo "Done with merge"
+      - name: Push to dev
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: dev


### PR DESCRIPTION
## Add GitHub Workflow to Auto-Merge `main` into `dev`

## Problem

Right now `main `is constantly floating out of date with the `dev` branch with the weekly updates to the metrics site. `dev` should not be out of date with `main`

## Solution

Created a GitHub workflow to automatically merge `main` into `dev` whenever there's a new commit in `main`.
