### PR TITLE
Add Augur 'Days to First Response for Merged Pull Requests' Graph to Repo Reports

### DIFF
--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -10,3 +10,18 @@
   flex-direction: column;
   align-items: center;
 }
+
+/*
+This is so that augur visualizations have the buttons cropped out.
+*/
+.firstResponsePRCrop {
+  width: 900px;
+  height: 600px;
+  overflow: hidden;
+}
+
+.firstResponsePRCrop img {
+  width: 900px;
+  height: 632px;
+  margin: -55px 0 0 0;
+}

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -69,12 +69,14 @@ class BaseMetric:
                 Dictionary of parameters to apply to endpoint.
         """
         request_params = params
+        endpoint_to_hit = self.url
+
         if params and len(params) > 0 and self.method == 'GET':
-            self.url = self.url.format(**params)
+            endpoint_to_hit = self.url.format(**params)
             request_params = None
 
         if self.headers:
-            _args_ = (self.method, self.url)
+            _args_ = (self.method, endpoint_to_hit)
             _kwargs_ = {
                 "params": request_params,
                 "headers": self.headers,
@@ -83,7 +85,7 @@ class BaseMetric:
             response = requests.request(*_args_, **_kwargs_)
         else:
             response = requests.request(
-                self.method, self.url, params=request_params, timeout=TIMEOUT_IN_SECONDS)
+                self.method, endpoint_to_hit, params=request_params, timeout=TIMEOUT_IN_SECONDS)
         try:
             response_json = json.loads(response.text)
         except JSONDecodeError:
@@ -439,7 +441,11 @@ def parse_commits_by_month(**kwargs):
     # print(metric_json)
     for commit in metric_json:
         # Get the month and year of the commit
-        datetime_str = commit['commit']['author']['date']
+        try:
+            datetime_str = commit['commit']['author']['date']
+        except TypeError:
+            print(commit)
+            continue
         date_obj = datetime.datetime.strptime(
             datetime_str, '%Y-%m-%dT%H:%M:%SZ')
         month = f"{date_obj.year}/{date_obj.month}"

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -179,13 +179,14 @@ class ResourceMetric(BaseMetric):
         path = oss_entity.get_path_to_resource_data(self.name, fmt=self.format)
 
         if r.status_code == 200:
-            if r.text == (errtext := "There is no data for this repo, in the database you are accessing"):
+            errtext = "There is no data for this repo, in the database you are accessing"
+            if r.text == errtext:
                 print(errtext)
                 return {}
 
             with open(path, "wb+") as f:
                 f.write(r.content)
-            
+
             print(f"Path: {path}")
         else:
             print(f"Status code: {r.status_code}")

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -177,6 +177,8 @@ class ResourceMetric(BaseMetric):
         if r.status_code == 200:
             with open(path, "wb+") as f:
                 f.write(r.content)
+            
+            print(f"Path: {path}")
         else:
             print(f"Status code: {r.status_code}")
         return {}

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -149,13 +149,15 @@ class ResourceMetric(BaseMetric):
             params: dict
                 Dictionary of parameters to apply to endpoint.
         """
+
+        endpoint_to_hit = self.url
         request_params = params
         if params and len(params) > 0 and self.method == 'GET':
-            self.url = self.url.format(**params)
+            endpoint_to_hit = self.url.format(**params)
             request_params = None
 
         if self.headers:
-            _args_ = (self.method, self.url)
+            _args_ = (self.method, endpoint_to_hit)
             _kwargs_ = {
                 "params": request_params,
                 "headers": self.headers,
@@ -165,7 +167,7 @@ class ResourceMetric(BaseMetric):
             response = requests.request(*_args_, **_kwargs_)
         else:
             response = requests.request(
-                self.method, self.url, params=request_params, timeout=TIMEOUT_IN_SECONDS)
+                self.method, endpoint_to_hit, params=request_params, timeout=TIMEOUT_IN_SECONDS)
         # return response
         return response
 
@@ -175,6 +177,9 @@ class ResourceMetric(BaseMetric):
         path = oss_entity.get_path_to_resource_data(self.name, fmt=self.format)
 
         if r.status_code == 200:
+            if r.text == (errtext := "There is no data for this repo, in the database you are accessing"):
+                print(errtext)
+
             with open(path, "wb+") as f:
                 f.write(r.content)
             

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -179,6 +179,7 @@ class ResourceMetric(BaseMetric):
         if r.status_code == 200:
             if r.text == (errtext := "There is no data for this repo, in the database you are accessing"):
                 print(errtext)
+                return {}
 
             with open(path, "wb+") as f:
                 f.write(r.content)
@@ -319,7 +320,7 @@ class ListMetric(BaseMetric):
 
         to_return = {}
 
-        # print(f"URL: {self.url}")
+        #print(f"URL: {self.url}")
         for return_label, api_label in self.return_values.items():
             # Allow for multiple keys of each returned element to be stored.
             # EX: storing the date and count of each time the amount of followers

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -138,7 +138,7 @@ PERIODIC_METRICS.append(ListMetric("issuesNewMonthly", sixMonthsParams,
 
 RESOURCE_METRICS.append(ResourceMetric("firstResponseForClosedPR", sixMonthsParams,
                                 AUGUR_HOST + "/pull_request_reports/PR_time_to_first_response/" +
-                                "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))
+                                "?repo_id={repo_id}"))
 
 
 ORG_GITHUB_GRAPHQL_QUERY = """

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -2,7 +2,7 @@
 Definitions of specific metrics for metricsLib
 """
 from metricsLib.metrics_data_structures import CustomMetric, parse_commits_by_month
-from metricsLib.metrics_data_structures import GraphQLMetric, SumMetric
+from metricsLib.metrics_data_structures import GraphQLMetric, SumMetric, ResourceMetric
 from metricsLib.metrics_data_structures import ListMetric
 from metricsLib.constants import TOKEN, AUGUR_HOST
 
@@ -136,11 +136,9 @@ PERIODIC_METRICS.append(ListMetric("issuesNewMonthly", sixMonthsParams,
                                    "period={period}&begin_date={begin_month}&end_date={end_date}",
                                    {"new_issues_by_day_over_last_six_months": ["date", "issues"]}))
 
-# TODO: Ask Sean why this endpoint isn't working for any repo except for augur.
-# might just be lack of data.
-#RESOURCE_METRICS.append(ResourceMetric("firstResponseForClosedPR", sixMonthsParams,
-#                                AUGUR_HOST + "/pull_request_reports/PR_time_to_first_response/" +
-#                                "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))
+RESOURCE_METRICS.append(ResourceMetric("firstResponseForClosedPR", sixMonthsParams,
+                                AUGUR_HOST + "/pull_request_reports/PR_time_to_first_response/" +
+                                "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))
 
 
 ORG_GITHUB_GRAPHQL_QUERY = """
@@ -177,17 +175,17 @@ ORG_METRICS.append(
               FOLLOWERS_ENDPOINT, "followers_count", token=TOKEN)
 )
 
-#ORG_METRICS.append(ListMetric("issueNewWeekly", ["repo_group_id","period","begin_week","end_date"],
-#                              AUGUR_HOST +
-#                              "/repo-groups/{repo_group_id}/issues-new" +
-#                              "?period={period}&begin_date={begin_week}&end_date={end_date}",
-#                              {"new_issues_by_day_over_last_month": ["date", "issues"]}))
+ORG_METRICS.append(ListMetric("issueNewWeekly", ["repo_group_id","period","begin_week","end_date"],
+                              AUGUR_HOST +
+                              "/repo-groups/{repo_group_id}/issues-new" +
+                              "?period={period}&begin_date={begin_week}&end_date={end_date}",
+                              {"new_issues_by_day_over_last_month": ["date", "issues"]}))
 
-#ORG_METRICS.append(ListMetric("issueNewMonthly",["repo_group_id","period","begin_month","end_date"],
-#                              AUGUR_HOST +
-#                              "/repo-groups/{repo_group_id}/issues-new" +
-#                              "?period={period}&begin_date={begin_month}&end_date={end_date}",
-#                              {"new_issues_by_day_over_last_six_months": ["date", "issues"]}))
+ORG_METRICS.append(ListMetric("issueNewMonthly",["repo_group_id","period","begin_month","end_date"],
+                              AUGUR_HOST +
+                              "/repo-groups/{repo_group_id}/issues-new" +
+                              "?period={period}&begin_date={begin_month}&end_date={end_date}",
+                              {"new_issues_by_day_over_last_six_months": ["date", "issues"]}))
 
 COMMITS_ENDPOINT = "https://api.github.com/repos/{owner}/{repo}/commits"
 SIMPLE_METRICS.append(CustomMetric("getCommitsByMonth", [

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -138,7 +138,7 @@ PERIODIC_METRICS.append(ListMetric("issuesNewMonthly", sixMonthsParams,
 
 RESOURCE_METRICS.append(ResourceMetric("firstResponseForClosedPR", sixMonthsParams,
                                 AUGUR_HOST + "/pull_request_reports/PR_time_to_first_response/" +
-                                "?repo_id={repo_id}"))
+                                "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))
 
 
 ORG_GITHUB_GRAPHQL_QUERY = """

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -229,7 +229,7 @@ class Repository(OSSEntity):
         # print(repo_val)
         self.repo_id = repo_val['repo_id']
 
-        print(f"repo id: {self.repo_id}")
+        #print(f"repo id: {self.repo_id}")
         if owner_id is not None:
             self.repo_group_id = owner_id
         else:

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -229,6 +229,7 @@ class Repository(OSSEntity):
         # print(repo_val)
         self.repo_id = repo_val['repo_id']
 
+        print(f"repo id: {self.repo_id}")
         if owner_id is not None:
             self.repo_group_id = owner_id
         else:

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -108,5 +108,8 @@ date_stampLastWeek: {date_stamp}
     <figure>
       <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
     </figure>
+    <figure>
+      <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
+    </figure>
   </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -108,8 +108,10 @@ date_stampLastWeek: {date_stamp}
     <figure>
       <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
     </figure>
-    <figure>
-      <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
-    </figure>
+    <div class="firstResponsePRCrop">
+      <figure>
+        <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" | url }}}}" />
+      </figure>
+    </div>
   </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -108,6 +108,7 @@ date_stampLastWeek: {date_stamp}
     <figure>
       <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
     </figure>
+    <!--- First Response For Closed PR Scatterplot -->
     <div class="firstResponsePRCrop">
       <figure>
         <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" | url }}}}" />


### PR DESCRIPTION
## Add Augur 'Days to First Response for Merged Pull Requests' Graph to Repo Reports


## Problem

Currently we do not have all of the desired visualizations for the V1 of the metrics website.

## Solution

This PR adds the first planned visualization to the metrics website from Augur; the 'Days to First Response for Merged Pull Requests' graph.

## Result

- Uncomment Augur Metrics
- Patch bug when fetching ListMetric metrics where url was not properly formatted and mistakenly fetched information for other repos.
- Add CSS to crop the graph to hide buttons that are included by mistake upstream
- Add better error handling for ResourceMetric
- Add Image to repo report template
