### PR TITLE
Added Search to List of Projects Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ app/node_modules
 app/dist
 app/.env
 app/site/img/*
-app/site/_includes
+app/site/_includes/css
+app/site/_includes/js
 !app/site/img/.keep
 .vscode/
 scripts/metricsLib/__pycache__

--- a/app/rollup.config.mjs
+++ b/app/rollup.config.mjs
@@ -10,6 +10,11 @@ export default [
       file: "site/_includes/js/index.js",
       format: "esm",
     },
+    input: "src/js/projects.js",
+    output: {
+      file: "site/_includes/js/projects.js",
+      format: "esm",
+    },
     plugins: [
       resolve(),
       babel(),

--- a/app/site/_includes/project-card.liquid
+++ b/app/site/_includes/project-card.liquid
@@ -1,0 +1,49 @@
+<li class="usa-card project-card tablet:grid-col-12" org-name="{{ repo.owner }}">
+    <div class="usa-card__container">
+      <div class="usa-card__header">
+        <h2 class="usa-card__heading">
+          <a href={{ repo.link | url }} class="text-no-underline">{{ repo.name }}</a>
+        </h2>
+      </div>
+      <div class="usa-card__body">
+        <div>{{ repo.description }}</div>
+      </div>
+      <div class="usa-card__footer">
+        <span class="star-count" style="margin-right: 15px;">
+          <svg class="usa-icon" aria-labelledby="star-count-{{repo.name}}-title" role="img">
+            <title id="github-{{repo.name}}-title"> Star Count</title>
+            {% lucide "star" %}
+          </svg>
+          <span> {{ repo.stargazers_count }} </span>
+        </span>
+        <span class="fork-count" style="margin-right: 15px;">
+          <svg class="usa-icon" aria-labelledby="fork-count-{{repo.name}}-title" role="img">
+            <title id="github-{{repo.name}}-title"> Fork Count</title>
+            {% lucide "git-fork" %}
+          </svg>
+          <span> {{ repo.forks_count }} </span>
+        </span>
+        <span class="issue-count" style="margin-right: 15px;">
+          <svg class="usa-icon" aria-labelledby="issue-count-{{ repo.name }}-title" role="img">
+            <title id="github-{{repo.name}}-title"> Issue Count</title>
+            {% lucide "circle-dot" %}
+          </svg>
+          <span> {{ repo.issues_count }} </span>
+        </span>
+        <span class="pull-request-count" style="margin-right: 15px;">
+          <svg class="usa-icon" aria-labelledby="pull-request-count-{{repo.name}}-title" role="img">
+            <title id="github-{{repo.name}}-title"> Pull Request Count</title>
+            {% lucide "git-pull-request" %}
+          </svg>
+          <span> {{ repo.pull_requests_count }} </span>
+        </span>
+        <span class="watchers-count">
+          <svg class="usa-icon" aria-labelledby="watchers-count-{{repo.name}}-title" role="img">
+            <title id="github-{{repo.name}}-title"> Watchers Count</title>
+            {% lucide "eye" %}
+          </svg>
+          <span> {{ repo.watchers_count }} </span>
+        </span>
+      </div>
+    </div>
+  </li>

--- a/app/site/_includes/project-card.liquid
+++ b/app/site/_includes/project-card.liquid
@@ -3,7 +3,7 @@
     <div class="usa-card__container">
       <div class="usa-card__header">
         <h2 class="usa-card__heading">
-          <a href={{ new_link_var | url }} class="text-no-underline">{{ repo.name }}</a>
+          <a href="{{ base_url }}/{{ repo.owner }}/{{ repo.name }}/" class="text-no-underline">{{ repo.name }}</a>
         </h2>
       </div>
       <div class="usa-card__body">

--- a/app/site/_includes/project-card.liquid
+++ b/app/site/_includes/project-card.liquid
@@ -1,8 +1,9 @@
+{% capture new_link_var %}/{{ repo.owner }}/{{ repo.name }}/{% endcapture %}
 <li class="usa-card project-card tablet:grid-col-12" org-name="{{ repo.owner }}">
     <div class="usa-card__container">
       <div class="usa-card__header">
         <h2 class="usa-card__heading">
-          <a href={{ repo.link | url }} class="text-no-underline">{{ repo.name }}</a>
+          <a href={{ new_link_var | url }} class="text-no-underline">{{ repo.name }}</a>
         </h2>
       </div>
       <div class="usa-card__body">

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -21,7 +21,7 @@ layout: base
   </div>
 
   {% for org in organizations %}
-    <div class="project_section" org-name={{ org.name }}>
+    <div class="project_section">
       <div class="report_heading">
         <h2>
           {{ org.name }}

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -13,10 +13,10 @@ layout: base
     <div class="usa-input-group width-full maxw-none">
       <div class="usa-input-prefix" aria-hidden="true">
         <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
-          <use xlink:href="/assets/img/sprite.svg#search"></use>
+          <use xlink:href={{  "/assets/img/sprite.svg#search"| url }} ></use>
         </svg>
       </div>
-      <input class="usa-input" id="filter-input" name="filter-input">
+      <input class="usa-input--lg" id="filter-input" name="filter-input">
     </div>
   </div>
 

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -35,7 +35,9 @@ layout: base
 
       <ul class="usa-card-group flex-align-stretch">
         {% assign orgProjects = projects | findProjectsInOrg: org.name %}
-        {% render "project-card" for orgProjects as repo %}
+        {% for repo in orgProjects %}
+          {% render "project-card", repo: repo, base_url: site.baseurl %}
+        {% endfor %}
       </ul>
     </div>
   {% endfor %}

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-<script type="module" src="{{ "/assets/js/projects.js" | url}}"></script>
+<script type="module" src="{{ "/assets/js/projects.js" | url }}"></script>
 <div class="grid-container">
   <p>
     The Centers for Medicare and Medicaid Services develops and supports many open-source projects found in our various
@@ -21,70 +21,22 @@ layout: base
   </div>
 
   {% for org in organizations %}
-    <div class="report_heading">
-      <h2>
-        {{ org.name }}
-        <img
-          src="{{org.avatar_url}}"
-          alt="Organization Avatar"
-          width="20"
-        >
-      </h2>
-    </div>
+    <div class="project_section" org-name={{ org.name }}>
+      <div class="report_heading">
+        <h2>
+          {{ org.name }}
+          <img
+            src="{{org.avatar_url}}"
+            alt="Organization Avatar"
+            width="20"
+          >
+        </h2>
+      </div>
 
-    <ul class="usa-card-group flex-align-stretch">
-      {% assign orgProjects = projects | findProjectsInOrg: org.name %}
-      {% for repo in orgProjects %}
-        <li class="usa-card project-card tablet:grid-col-12" org-name="{{ org.name }}">
-          <div class="usa-card__container">
-            <div class="usa-card__header">
-              <h2 class="usa-card__heading">
-                <a href="{{ site.baseurl }}/{{ repo.owner }}/{{ repo.name }}/" class="text-no-underline">{{ repo.name }}</a>
-              </h2>
-            </div>
-            <div class="usa-card__body">
-              <div>{{ repo.description }}</div>
-            </div>
-            <div class="usa-card__footer">
-              <span class="star-count" style="margin-right: 15px;">
-                <svg class="usa-icon" aria-labelledby="star-count-{{repo.name}}-title" role="img">
-                  <title id="github-{{repo.name}}-title"> Star Count</title>
-                  {% lucide "star" %}
-                </svg>
-                <span> {{ repo.stargazers_count }} </span>
-              </span>
-              <span class="fork-count" style="margin-right: 15px;">
-                <svg class="usa-icon" aria-labelledby="fork-count-{{repo.name}}-title" role="img">
-                  <title id="github-{{repo.name}}-title"> Fork Count</title>
-                  {% lucide "git-fork" %}
-                </svg>
-                <span> {{ repo.forks_count }} </span>
-              </span>
-              <span class="issue-count" style="margin-right: 15px;">
-                <svg class="usa-icon" aria-labelledby="issue-count-{{repo.name}}-title" role="img">
-                  <title id="github-{{repo.name}}-title"> Issue Count</title>
-                  {% lucide "circle-dot" %}
-                </svg>
-                <span> {{ repo.issues_count }} </span>
-              </span>
-              <span class="pull-request-count" style="margin-right: 15px;">
-                <svg class="usa-icon" aria-labelledby="pull-request-count-{{repo.name}}-title" role="img">
-                  <title id="github-{{repo.name}}-title"> Pull Request Count</title>
-                  {% lucide "git-pull-request" %}
-                </svg>
-                <span> {{ repo.pull_requests_count }} </span>
-              </span>
-              <span class="watchers-count">
-                <svg class="usa-icon" aria-labelledby="watchers-count-{{repo.name}}-title" role="img">
-                  <title id="github-{{repo.name}}-title"> Watchers Count</title>
-                  {% lucide "eye" %}
-                </svg>
-                <span> {{ repo.watchers_count }} </span>
-              </span>
-            </div>
-          </div>
-        </li>
-      {% endfor %}
-    </ul>
+      <ul class="usa-card-group flex-align-stretch">
+        {% assign orgProjects = projects | findProjectsInOrg: org.name %}
+        {% render "project-card" for orgProjects as repo %}
+      </ul>
+    </div>
   {% endfor %}
 </div>

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -1,11 +1,24 @@
 ---
 layout: base
 ---
+<script type="module" src="/assets/js/projects.js"></script>
 <div class="grid-container">
   <p>
     The Centers for Medicare and Medicaid Services develops and supports many open-source projects found in our various
     GitHub Organizations.
   </p>
+
+  <div class="margin-bottom-2">
+    <label class="usa-label" for="filter-input">Search</label>
+    <div class="usa-input-group width-full maxw-none">
+      <div class="usa-input-prefix" aria-hidden="true">
+        <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+          <use xlink:href="/assets/img/sprite.svg#search"></use>
+        </svg>
+      </div>
+      <input class="usa-input" id="filter-input" name="filter-input">
+    </div>
+  </div>
 
   {% for org in organizations %}
     <div class="report_heading">

--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-<script type="module" src="/assets/js/projects.js"></script>
+<script type="module" src="{{ "/assets/js/projects.js" | url}}"></script>
 <div class="grid-container">
   <p>
     The Centers for Medicare and Medicaid Services develops and supports many open-source projects found in our various
@@ -35,7 +35,7 @@ layout: base
     <ul class="usa-card-group flex-align-stretch">
       {% assign orgProjects = projects | findProjectsInOrg: org.name %}
       {% for repo in orgProjects %}
-        <li class="usa-card project-card tablet:grid-col-12">
+        <li class="usa-card project-card tablet:grid-col-12" org-name="{{ org.name }}">
           <div class="usa-card__container">
             <div class="usa-card__header">
               <h2 class="usa-card__heading">

--- a/app/src/js/projects.js
+++ b/app/src/js/projects.js
@@ -1,0 +1,9 @@
+const filterBox = document.getElementById("filter-input")
+filterBox.addEventListener("input", () => {
+  const query = filterBox.value.toLowerCase()
+  document.querySelectorAll(".project-card").forEach((card) => {
+    card.hidden = !(
+      query == "" || card.textContent.toLowerCase().includes(query)
+    )
+  })
+})

--- a/app/src/js/projects.js
+++ b/app/src/js/projects.js
@@ -1,34 +1,27 @@
 const filterBox = document.getElementById("filter-input")
-const reportHeadings = document.querySelectorAll(".report_heading")
-const projectCards = document.querySelectorAll(".project-card")
+const projectSections = document.querySelectorAll(".project_section")
 
 filterBox.addEventListener("input", () => {
   const query = filterBox.value.toLowerCase()
 
-  // Initiaize dictionary that tracks count of displayed cards under org
-  const orgDict = {}
-  reportHeadings.forEach(org => {
-    const name = org.innerText.trim()
-    orgDict[name] = 0;
-  })
+  // Iterate through each section
+  projectSections.forEach(section => {
+    var queryMatchCheck = false
+    const projectCards = section.querySelectorAll(".project-card")
 
-  // Performs query and hides project card accordingly.
-  projectCards.forEach((card) => {
-    card.hidden = !(
-      query == "" || card.textContent.toLowerCase().includes(query)
-    )
+    // Performs query and hides project card accordingly
+    projectCards.forEach((card) => {
+      card.hidden = !(
+        query == "" || card.textContent.toLowerCase().includes(query)
+      )
 
-    // Updates count
-    const org = card.getAttribute("org-name");
-    if (!card.hidden) {
-      orgDict[org] += 1
-    }
-  })
+      if(!card.hidden) {
+        queryMatchCheck = true
+      }
+    })
 
-  // Displays org heading accordingly
-  reportHeadings.forEach(org => {
-    const name = org.innerText.trim()
-    org.hidden = !orgDict[name];
+    // Hide heading if all cards under section are hidden
+    const reportHeadings = section.querySelector(".report_heading")
+    reportHeadings.hidden = !queryMatchCheck
   })
-  
 })

--- a/app/src/js/projects.js
+++ b/app/src/js/projects.js
@@ -1,9 +1,34 @@
 const filterBox = document.getElementById("filter-input")
+const reportHeadings = document.querySelectorAll(".report_heading")
+const projectCards = document.querySelectorAll(".project-card")
+
 filterBox.addEventListener("input", () => {
   const query = filterBox.value.toLowerCase()
-  document.querySelectorAll(".project-card").forEach((card) => {
+
+  // Initiaize dictionary that tracks count of displayed cards under org
+  const orgDict = {}
+  reportHeadings.forEach(org => {
+    const name = org.innerText.trim()
+    orgDict[name] = 0;
+  })
+
+  // Performs query and hides project card accordingly.
+  projectCards.forEach((card) => {
     card.hidden = !(
       query == "" || card.textContent.toLowerCase().includes(query)
     )
+
+    // Updates count
+    const org = card.getAttribute("org-name");
+    if (!card.hidden) {
+      orgDict[org] += 1
+    }
   })
+
+  // Displays org heading accordingly
+  reportHeadings.forEach(org => {
+    const name = org.innerText.trim()
+    org.hidden = !orgDict[name];
+  })
+  
 })


### PR DESCRIPTION
## Added Search to List of Projects Page

## Problem

The number of organizations and projects that will be added to the website will be growing, thus search will be needed in order to easily find certain projects/repos.

## Solution

Added Search to Page with List of Projects
- Created `app/src/js/projects.js` with search functionality, inspired by code in `/open` repo. Added new .js file to rollup config
- Refactored some `project.liquid` code by creating`project-card.liquid`, a component for project card. This will make it easier for future development regarding search + filters for project cards.

## Result
Text in search bar hides cards that do not match query.

## Test Plan
Manually verified changes.