### PR TITLE
Update Key to Use Better GitHub Key

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Push to dev
         uses: CasperWA/push-protected@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.METRICS_GITHUB_TOKEN }}
           branch: dev


### PR DESCRIPTION
## Update Key to Use Better GitHub Key

## Problem

The current key is not privileged enough. 

## Solution

Use key that we were using for update data.
