### PR TITLE
Add Issue Graph Generation to Org Report

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -28,6 +28,7 @@ def generate_all_graphs_for_orgs(all_orgs):
     for org in all_orgs:
         print(f"Generating graphs for org {org.name}")
         generate_solid_gauge_issue_graph(org)
+        generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_six_months")
 
 
 def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_func_params={}):
@@ -78,6 +79,27 @@ def generate_repo_sparklines(repo):
     write_repo_chart_to_file(
         repo, chart, "commit_sparklines",
         custom_func=chart.render_sparkline, custom_func_params=_kwargs_)
+
+
+def generate_time_xy_issue_graph(oss_entity,data_key):
+    """
+    This function generates pygals xy time graph for new issue creation over a time period.
+
+    Arguments:
+        oss_entity: the OSSEntity to create a graph for
+        data_key: key of the dictionary to use to generate the time graph
+    """
+
+    graph_data_dict = oss_entity.metric_data[data_key]
+    dates_list = [record[0] for record in graph_data_dict]
+    issues_list = [record[1] for record in graph_data_dict]
+
+    xy_time_issue_chart = pygal.Line(x_label_rotation=20)
+    xy_time_issue_chart.x_labels = dates_list
+    xy_time_issue_chart.add("Issues", issues_list)
+
+    write_repo_chart_to_file(oss_entity, xy_time_issue_chart, data_key)
+
 
 
 def generate_solid_gauge_issue_graph(oss_entity):

--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -109,5 +109,8 @@ date_stampLastWeek: {date_stamp}
     <figure>
       <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_owner}_issue_gauge.svg" | url }}}}" />
     </figure>
+    <figure>
+      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg" | url }}}}" />
+    </figure>
   </div>
 </div>


### PR DESCRIPTION
## Add Issue Graph Generation to Org Report

## Problem

The required graph of issues created over time for the V1 of the metrics website is missing. 

## Solution

Now, the graph is generated and is apart of the template for orgs. Currently the only graph generated is the one for orgs over a six month period but I will add the others through other PRs.

