### PR TITLE
Add Donut Graphs for Repository Line Makeup 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "metrics",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -16,6 +16,7 @@ def generate_all_graphs_for_repos(all_repos):
         print(f"Generating graphs for repo {repo.name}")
         generate_solid_gauge_issue_graph(repo)
         generate_repo_sparklines(repo)
+        generate_donut_graph_line_complexity_graph(repo)
 
 
 def generate_all_graphs_for_orgs(all_orgs):
@@ -100,6 +101,31 @@ def generate_time_xy_issue_graph(oss_entity,data_key):
 
     write_repo_chart_to_file(oss_entity, xy_time_issue_chart, data_key)
 
+
+def generate_donut_graph_line_complexity_graph(oss_entity):
+    """
+    This function generates pygals line complexitydonut graph
+    for a set of Repository objects.
+
+    Arguments:
+        oss_entity: The OSSEntity to create a graph for.
+    """
+
+    donut_lines_graph = pygal.Pie(inner_radius=0.65)
+    donut_lines_graph.title = "Composition of Lines of Code"
+
+
+    num_blank_lines = oss_entity.metric_data['total_project_blank_lines']
+    donut_lines_graph.add('Total Blank Lines', num_blank_lines)
+
+    num_comment_lines = oss_entity.metric_data['total_project_comment_lines']
+    donut_lines_graph.add('Total Comment Lines', num_comment_lines)
+
+    num_total_lines = oss_entity.metric_data['total_project_lines']
+    num_remaining_lines = (num_total_lines - num_comment_lines) - num_blank_lines
+    donut_lines_graph.add('Total Other Lines', num_remaining_lines)
+
+    write_repo_chart_to_file(oss_entity, donut_lines_graph, "total_line_makeup")
 
 
 def generate_solid_gauge_issue_graph(oss_entity):

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -92,7 +92,7 @@ def generate_time_xy_issue_graph(oss_entity,data_key):
     """
 
     graph_data_dict = oss_entity.metric_data[data_key]
-    
+
     dates_list = [record[0] for record in graph_data_dict]
     issues_list = [record[1] for record in graph_data_dict]
 
@@ -180,51 +180,3 @@ def generate_solid_gauge_issue_graph(oss_entity):
             {'label': "Closed Pull Requests", 'value': closed_pr_percent * 100, 'max_value': 100}])
 
     write_repo_chart_to_file(oss_entity, issues_gauge, "issue_gauge")
-
-
-# TODO: Just get these metrics from augur instead of storing them in json.
-
-# def genOverview():
-#    treemap = pygal.Treemap()
-#    treemap.title = 'DSACMS Project Overview Binary TreeMap'
-#
-#    for file in os.listdir():
-#        try:
-#            f = open(file)
-#            data = json.load(f)
-#            d = []
-#            words = file.split("-METRICS")
-#
-#            for key in data:
-#                if (data[key] != 0 and data[key] != None):
-#                    d.append(data[key])
-#            d.pop(0)
-#
-#            treemap.add(words[0], d)
-#        except:
-#            invalid = []
-#            invalid.append(file)
-#
-#    treemap.render_to_file('overview.svg')
-#
-#
-# def repoSpecific():
-#    for file in os.listdir():
-#        try:
-#            treemap = pygal.Treemap()
-#            f = open(file)
-#            data = json.load(f)
-#            del data["datetime"]
-#
-#            for key in data:
-#                if (data[key] != 0 and data[key] != None):
-#                    treemap.add(key, data[key])
-#
-#            words = file.split("-METRICS")
-#            treemap.title = words[0] + " Binary TreeMap"
-#            treemap.render_to_file(words[0] + "-graph.svg")
-#            data.clear()
-#
-#        except:
-#            invalid = []
-#            invalid.append(file)

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -114,7 +114,7 @@ def generate_donut_graph_line_complexity_graph(oss_entity):
             a repository or an organization.
     """
 
-    donut_lines_graph = pygal.Pie(inner_radius=0.65)
+    donut_lines_graph = pygal.Pie(inner_radius=0.65,legend_at_bottom=True)
     donut_lines_graph.title = "Composition of Lines of Code"
 
 

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -92,7 +92,7 @@ def generate_time_xy_issue_graph(oss_entity,data_key):
     """
 
     graph_data_dict = oss_entity.metric_data[data_key]
-    print(graph_data_dict)
+    
     dates_list = [record[0] for record in graph_data_dict]
     issues_list = [record[1] for record in graph_data_dict]
 
@@ -105,11 +105,13 @@ def generate_time_xy_issue_graph(oss_entity,data_key):
 
 def generate_donut_graph_line_complexity_graph(oss_entity):
     """
-    This function generates pygals line complexitydonut graph
+    This function generates pygals line complexity donut graph
     for a set of Repository objects.
 
     Arguments:
-        oss_entity: The OSSEntity to create a graph for.
+        oss_entity: The OSSEntity to create a graph for. an 
+            OSSEntity is a data structure that is typically
+            a repository or an organization.
     """
 
     donut_lines_graph = pygal.Pie(inner_radius=0.65)

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -92,6 +92,7 @@ def generate_time_xy_issue_graph(oss_entity,data_key):
     """
 
     graph_data_dict = oss_entity.metric_data[data_key]
+    print(graph_data_dict)
     dates_list = [record[0] for record in graph_data_dict]
     issues_list = [record[1] for record in graph_data_dict]
 

--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -48,6 +48,7 @@ def get_heading_report_values(headings, oss_entity):
 
     report_values = {}
     for heading in headings:
+        print(oss_entity.metric_data)
         prev_record = oss_entity.metric_data[heading]
 
         if heading in oss_entity.previous_metric_data.keys():

--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -48,7 +48,6 @@ def get_heading_report_values(headings, oss_entity):
 
     report_values = {}
     for heading in headings:
-        print(oss_entity.metric_data)
         prev_record = oss_entity.metric_data[heading]
 
         if heading in oss_entity.previous_metric_data.keys():

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -316,6 +316,8 @@ class ListMetric(BaseMetric):
     def __init__(self, name, needed_params, endpoint_url, return_values, token=None, method='GET'):
         super().__init__(name, needed_params, endpoint_url,
                          return_values, token=token, method=method)
+        
+        self.tuple_flag = True
 
     def get_values(self, params=None):
         metric_json = self.hit_metric(params=params)
@@ -341,7 +343,10 @@ class ListMetric(BaseMetric):
                         elem.append(item[sub_label])
                     #print(elem)
                     # Add up sublists and assign to return label key
-                    to_return[return_label].extend(elem)
+                    if not self.tuple_flag:
+                        to_return[return_label].extend(elem)
+                    else:
+                        to_return[return_label].append(elem)
             except TypeError:
                 # return_label key is assigned to list of extracted api_label value
                 to_return[return_label] = [item[api_label]
@@ -366,6 +371,8 @@ class RangeMetric(ListMetric):
     def __init__(self, name, needed_params, endpoint_url, return_values, token=None, method='GET'):
         super().__init__(name, needed_params, endpoint_url,
                          return_values, token=token, method=method)
+        
+        self.tuple_flag = False
 
     def get_values(self, params=None):
         """

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -316,7 +316,7 @@ class ListMetric(BaseMetric):
     def __init__(self, name, needed_params, endpoint_url, return_values, token=None, method='GET'):
         super().__init__(name, needed_params, endpoint_url,
                          return_values, token=token, method=method)
-        
+
         self.tuple_flag = True
 
     def get_values(self, params=None):
@@ -371,7 +371,7 @@ class RangeMetric(ListMetric):
     def __init__(self, name, needed_params, endpoint_url, return_values, token=None, method='GET'):
         super().__init__(name, needed_params, endpoint_url,
                          return_values, token=token, method=method)
-        
+
         self.tuple_flag = False
 
     def get_values(self, params=None):

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -114,5 +114,10 @@ date_stampLastWeek: {date_stamp}
         <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" | url }}}}" />
       </figure>
     </div>
+    <!--- Line Complexity Graphs -->
+    <h3>Line Complexity</h3>
+    <figure>
+      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg" | url }}}}" />
+    </figure>
   </div>
 </div>


### PR DESCRIPTION
## Add Donut Graphs for Repository Line Makeup 

## Problem

There was no line composition graph to match the line composition metrics that were recently added. 

There was also a minor bug in the issue gathering logic. 

## Solution

Add another graph generation method to create a PyGals Pie chart with an inner radius. The values of the line composition are calculated from the [previously gathered metrics](#95). 

## Result

Alter the class definitions for `RangeMetric` and `ListMetric` to fix a niche bug where tuples were combined in the larger list generated as is the behavior for `RangeMetric`.

Add the aforementioned Pie graph with the proper radius set. The three pie sections are: comments, blank lines, and other. Here is an example of the donut graph:
![total_line_makeup_metrics_data](https://github.com/DSACMS/metrics/assets/24639268/b7aeb8dc-7051-4f02-a4e4-abee784fa569)

