### PR TITLE
Add All Missing Time-boxed Graphs

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -17,6 +17,8 @@ def generate_all_graphs_for_repos(all_repos):
         generate_solid_gauge_issue_graph(repo)
         generate_repo_sparklines(repo)
         generate_donut_graph_line_complexity_graph(repo)
+        generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_month")
+        generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_six_months")
 
 
 def generate_all_graphs_for_orgs(all_orgs):
@@ -30,6 +32,7 @@ def generate_all_graphs_for_orgs(all_orgs):
         print(f"Generating graphs for org {org.name}")
         generate_solid_gauge_issue_graph(org)
         generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_six_months")
+        generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_month")
 
 
 def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_func_params={}):

--- a/scripts/metricsLib/constants.py
+++ b/scripts/metricsLib/constants.py
@@ -5,7 +5,7 @@ import datetime
 import os
 from pathlib import Path
 
-TIMEOUT_IN_SECONDS = 5
+TIMEOUT_IN_SECONDS = 20
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 # Folder Names to send over our projects tracked data
 PATH_TO_METRICS_DATA = (Path(__file__).parent /

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -173,7 +173,11 @@ class ResourceMetric(BaseMetric):
         return response
 
     def get_values(self, oss_entity, params=None):
-        r = self.hit_metric(params=params)
+        try:
+            r = self.hit_metric(params=params)
+        except TimeoutError as e:
+            print(f"Request timeout out  for metric {self.name}: {e}")
+            return {}
 
         path = oss_entity.get_path_to_resource_data(self.name, fmt=self.format)
 


### PR DESCRIPTION
## Add All Missing Time-boxed Graphs

## Problem

Only one of the desired time-boxed graphs was generated previously in the dev branch. This was intended as a proof of concept. 

## Solution

Now, all of the time-boxed graphs are generated with the script. Also, an issue with timeouts not being handled correctly was fixed. 

## Result

All of the proper time-boxed graphs are now generated. Modifications to the repo and org templates to integrate with @natalialuzuriaga's changes will need to be made. 

