### PR TITLE
Reports: Check for File Existence

### DIFF
--- a/app/.eleventy.js
+++ b/app/.eleventy.js
@@ -58,10 +58,10 @@ module.exports = function (eleventyConfig) {
     return array.filter((item) => item["owner"] === value)
   })
 
-  eleventyConfig.addFilter('fileExists', function(filePath) {
-    const fs = require('fs');
-    return fs.existsSync(filePath);
-  });
+  eleventyConfig.addFilter("fileExists", function (filePath) {
+    const fs = require("fs")
+    return fs.existsSync(filePath)
+  })
 
   // Create a collection of items without permalinks so that we can reference them
   // in a separate shortcode to pull in partial content directly

--- a/app/.eleventy.js
+++ b/app/.eleventy.js
@@ -58,6 +58,11 @@ module.exports = function (eleventyConfig) {
     return array.filter((item) => item["owner"] === value)
   })
 
+  eleventyConfig.addFilter('fileExists', function(filePath) {
+    const fs = require('fs');
+    return fs.existsSync(filePath);
+  });
+
   // Create a collection of items without permalinks so that we can reference them
   // in a separate shortcode to pull in partial content directly
   eleventyConfig.addCollection("partials", (collectionApi) =>

--- a/app/site/_includes/graph-section.liquid
+++ b/app/site/_includes/graph-section.liquid
@@ -1,12 +1,17 @@
 {% assign className = class | default: "graph-container" %}
 {% assign devPath = "site/_graphs"| append: path %}
 {% assign distPath = baseurl | append: "/assets/img/graphs" | append: path %}
+{% assign fileExtension = path | split: '.' | last %}
 
 {% if devPath | fileExists %}
     <div class="{{ className }}">
         <h3>{{ title }}</h3>
         <figure>
+        {% if fileExtension == 'svg' %}
+            <embed type="image/svg+xml" src="{{ distPath }}" />
+        {% else %}
             <img src="{{ distPath }}"/>
+        {% endif %}
         </figure>
     </div>
 {% endif %}

--- a/app/site/_includes/graph-section.liquid
+++ b/app/site/_includes/graph-section.liquid
@@ -5,7 +5,7 @@
     <div class="graph-container">
         <h3>{{ title }}</h3>
         <figure>
-        <embed type="image/svg+xml" src={{ distPath | url }} />
+            <img src="{{ distPath }}" />
         </figure>
     </div>
 {% endif %}

--- a/app/site/_includes/graph-section.liquid
+++ b/app/site/_includes/graph-section.liquid
@@ -1,11 +1,12 @@
+{% assign className = class | default: "graph-container" %}
 {% assign devPath = "site/_graphs"| append: path %}
-{% assign distPath = "assets/img/graphs" | append: path %}
+{% assign distPath = baseurl | append: "/assets/img/graphs" | append: path %}
 
 {% if devPath | fileExists %}
-    <div class="graph-container">
+    <div class="{{ className }}">
         <h3>{{ title }}</h3>
         <figure>
-            <img src="{{ distPath }}" />
+            <img src="{{ distPath }}"/>
         </figure>
     </div>
 {% endif %}

--- a/app/site/_includes/graph-section.liquid
+++ b/app/site/_includes/graph-section.liquid
@@ -1,0 +1,11 @@
+{% assign devPath = "site/_graphs"| append: path %}
+{% assign distPath = "assets/img/graphs" | append: path %}
+
+{% if devPath | fileExists %}
+    <div class="graph-container">
+        <h3>{{ title }}</h3>
+        <figure>
+        <embed type="image/svg+xml" src={{ distPath | url }} />
+        </figure>
+    </div>
+{% endif %}

--- a/app/site/_includes/graph-section.liquid
+++ b/app/site/_includes/graph-section.liquid
@@ -1,17 +1,17 @@
-{% assign className = class | default: "graph-container" %}
-{% assign devPath = "site/_graphs"| append: path %}
-{% assign distPath = baseurl | append: "/assets/img/graphs" | append: path %}
+{% assign className = class | default: 'graph-container' %}
+{% assign devPath = 'site/_graphs' | append: path %}
+{% assign distPath = baseurl | append: '/assets/img/graphs' | append: path %}
 {% assign fileExtension = path | split: '.' | last %}
 
 {% if devPath | fileExists %}
-    <div class="{{ className }}">
-        <h3>{{ title }}</h3>
-        <figure>
-        {% if fileExtension == 'svg' %}
-            <embed type="image/svg+xml" src="{{ distPath }}" />
-        {% else %}
-            <img src="{{ distPath }}"/>
-        {% endif %}
-        </figure>
-    </div>
+  <div class="{{ className }}">
+    <h3>{{ title }}</h3>
+    <figure>
+      {% if fileExtension == 'svg' %}
+        <embed type="image/svg+xml" src="{{ distPath }}">
+      {% else %}
+        <img src="{{ distPath }}">
+      {% endif %}
+    </figure>
+  </div>
 {% endif %}

--- a/app/site/_includes/graph-toggle.liquid
+++ b/app/site/_includes/graph-toggle.liquid
@@ -24,7 +24,11 @@
             {% assign graphPath = graph | strip %}
             {% assign distPath = baseurl | append: "/assets/img/graphs" | append: graphPath %}
             <figure>
-                <img src="{{ distPath }}" />
+            {% if fileExtension == 'svg' %}
+                <embed type="image/svg+xml" src="{{ distPath }}" />
+            {% else %}
+                <img src="{{ distPath }}"/>
+            {% endif %}
             </figure>
             </div>
         {% endfor %}

--- a/app/site/_includes/graph-toggle.liquid
+++ b/app/site/_includes/graph-toggle.liquid
@@ -1,29 +1,44 @@
 {% assign graphName = name| append: "-graph" %}
 {% assign buttonName = name | append: "-button-" %}
+{% assign graphsCheck = true %}
 
-<div class="graph-container">
-    {% for graphing in graphs %}
-        {% if forloop.first %}
-            <div class={{ graphName }} id="{{ forloop.index0 }}">
-        {% else %}
-            <div class={{ graphName }} id="{{ forloop.index0 }}" style="display: none;">
-        {% endif %}
-        {% capture url %}{{ baseurl }}{{ graphing | strip }}{% endcapture %}
-        <figure>
-            <img src="{{ url }}" />
-        </figure>
-        </div>
-    {% endfor %}
-</div>
+{% comment %} Check for file existence of graphs {% endcomment %}
+{% for path in graphs %}
+    {% assign devPath = "site/_graphs"| append: path %}
+    {% unless devPath | fileExists %}
+      {% capture graphsCheck %}false{% endcapture %}
+      {% break %}
+    {% endunless %}
+{% endfor %}
 
-<ul class="usa-button-group ">
-    {% for option in options %}
-        <li class="usa-button-group__item">
-        {% if forloop.first %}
-            <button type="button" id={{ buttonName | append: forloop.index0 }} class="usa-button" onclick="showGraph({{ forloop.index0 }}, '{{ graphName }}','{{ buttonName }}')">{{ option }}</button>
-        {% else %}
-            <button type="button" id={{ buttonName | append: forloop.index0 }} class="usa-button usa-button--outline" onclick="showGraph({{ forloop.index0 }}, '{{ graphName }}','{{ buttonName }}')">{{ option }}</button>
-        {% endif %}
-        </li>
-    {% endfor %}
-</ul>
+{% comment %} Render components accordingly {% endcomment %}  
+{% if graphsCheck %}
+    <div class="graph-container">
+        <h3>{{ title }}</h3>
+        {% for graph in graphs %}
+            {% if forloop.first %}
+                <div class={{ graphName }} id="{{ forloop.index0 }}">
+            {% else %}
+                <div class={{ graphName }} id="{{ forloop.index0 }}" style="display: none;">
+            {% endif %}
+            {% assign distPath = "assets/img/graphs" | append: graph %}
+            {% capture url %}{{ baseurl }}{{ distPath | strip }}{% endcapture %}
+            <figure>
+                <img src="{{ url }}" />
+            </figure>
+            </div>
+        {% endfor %}
+
+        <ul class="usa-button-group ">
+            {% for option in options %}
+                <li class="usa-button-group__item">
+                {% if forloop.first %}
+                    <button type="button" id={{ buttonName | append: forloop.index0 }} class="usa-button" onclick="showGraph({{ forloop.index0 }}, '{{ graphName }}','{{ buttonName }}')">{{ option }}</button>
+                {% else %}
+                    <button type="button" id={{ buttonName | append: forloop.index0 }} class="usa-button usa-button--outline" onclick="showGraph({{ forloop.index0 }}, '{{ graphName }}','{{ buttonName }}')">{{ option }}</button>
+                {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}

--- a/app/site/_includes/graph-toggle.liquid
+++ b/app/site/_includes/graph-toggle.liquid
@@ -21,10 +21,10 @@
             {% else %}
                 <div class={{ graphName }} id="{{ forloop.index0 }}" style="display: none;">
             {% endif %}
-            {% assign distPath = "assets/img/graphs" | append: graph %}
-            {% capture url %}{{ baseurl }}{{ distPath | strip }}{% endcapture %}
+            {% assign graphPath = graph | strip %}
+            {% assign distPath = baseurl | append: "/assets/img/graphs" | append: graphPath %}
             <figure>
-                <img src="{{ url }}" />
+                <img src="{{ distPath }}" />
             </figure>
             </div>
         {% endfor %}

--- a/app/site/_layouts/org-report.liquid
+++ b/app/site/_layouts/org-report.liquid
@@ -1,6 +1,7 @@
 ---
 layout: base
 ---
+<script src="{{ "/assets/js/graphs.js" | url }}"></script>
 <div class="grid-container">
   {% assign organization = organizations | findObject: org %}
 

--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -10,7 +10,7 @@
   flex-direction: column;
   align-items: center;
 }
-
+/* This is so that augur visualizations have the buttons cropped out. */
 .firstResponsePRCrop img {
   width: 900px;
   height: 550px;

--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -11,17 +11,8 @@
   align-items: center;
 }
 
-/*
-This is so that augur visualizations have the buttons cropped out.
-*/
-.firstResponsePRCrop {
-  width: 900px;
-  height: 600px;
-  overflow: hidden;
-}
-
 .firstResponsePRCrop img {
   width: 900px;
-  height: 632px;
-  margin: -55px 0 0 0;
+  height: 550px;
+  object-fit: cover;
 }

--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -104,13 +104,10 @@ date_stampLastWeek: {date_stamp}
 <div class="graph-container">
   <br>
   <h2>Activity Graphs</h2>
-  <div class="row">
+  <div class="all-graphs">
     <!--- Issues/PRs Status Breakdown Graph -->
-    <figure>
-      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_owner}_issue_gauge.svg" | url }}}}" />
-    </figure>
-    <figure>
-      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg" | url }}}}" />
-    </figure>
+    {% render "graph-section" path: "/{repo_owner}/{repo_owner}_issue_gauge.svg", title: "Issues & PRs Status Breakdown" %}
+    <!-- New Issues over Last 6 Months -->
+    {% render "graph-section" path: "/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg", title: "New Issues over Last 6 Months" %}
   </div>
 </div>

--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -106,8 +106,8 @@ date_stampLastWeek: {date_stamp}
   <h2>Activity Graphs</h2>
   <div class="all-graphs">
     <!--- Issues/PRs Status Breakdown Graph -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_owner}_issue_gauge.svg", title: "Issues & PRs Status Breakdown" %}
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_issue_gauge.svg", title: "Issues & PRs Status Breakdown" %}}
     <!-- New Issues over Last 6 Months -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg", title: "New Issues over Last 6 Months" %}
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg", title: "New Issues over Last 6 Months" %}}
   </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -100,18 +100,18 @@ date_stampLastWeek: {date_stamp}
   <h2>Activity Graphs</h2>
   <div class="all-graphs">
     <!--- Issues/PRs Status Breakdown Graph -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" title: "Issues & PRs Status Breakdown" %}
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg", title: "Issues & PRs Status Breakdown" %}
     <!--- Contributor Activity Line Graph -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" title: "Commits by Month" %}
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg", title: "Commits by Month" %}
     <!--- First Response For Closed PR Scatterplot -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" title: "First Response For Closed PR" %}
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png", title: "First Response For Closed PR" %}
     <!--- Line Complexity Graphs -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg" title: "Line Complexity" %}
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg", title: "Line Complexity" %}
     <!--- Time Toggle Testing -->
     <h3>Number of Contributors Joining per Interval</h3>
     <div class="timeToggle">
-      {{% assign optionsArray = '1 Month, 6 Month' | split: ',' %}}
-      {{% assign graphsArray = '/assets/img/graphs/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /assets/img/graphs/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}}
-      {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray %}}
+      {% assign optionsArray = '1 Month, 6 Month' | split: ',' %}
+      {% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}
+      {% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}
     </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -108,10 +108,7 @@ date_stampLastWeek: {date_stamp}
     <!--- Line Complexity Graphs -->
     {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg", title: "Line Complexity" %}
     <!--- Time Toggle Testing -->
-    <h3>Number of Contributors Joining per Interval</h3>
-    <div class="timeToggle">
       {% assign optionsArray = '1 Month, 6 Month' | split: ',' %}
       {% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}
       {% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}
-    </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -98,28 +98,15 @@ date_stampLastWeek: {date_stamp}
 <div class="graph-container">
   <br>
   <h2>Activity Graphs</h2>
-  <div class="row">
+  <div class="all-graphs">
     <!--- Issues/PRs Status Breakdown Graph -->
-    <figure>
-      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" | url }}}}" />
-    </figure>
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg" title: "Issues & PRs Status Breakdown" %}
     <!--- Contributor Activity Line Graph -->
-    <h3>Commits by Month</h3>
-    <figure>
-      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" | url }}}}" />
-    </figure>
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg" title: "Commits by Month" %}
     <!--- First Response For Closed PR Scatterplot -->
-    <div class="firstResponsePRCrop">
-      <figure>
-        <img alt="firstResponseForClosedPR" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" | url }}}}" />
-      </figure>
-    </div>
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png" title: "First Response For Closed PR" %}
     <!--- Line Complexity Graphs -->
-    <h3>Line Complexity</h3>
-    <figure>
-      <embed type="image/svg+xml" src="{{{{ "/assets/img/graphs/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg" | url }}}}" />
-    </figure>
-  </div>
+    {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg" title: "Line Complexity" %}
     <!--- Time Toggle Testing -->
     <h3>Number of Contributors Joining per Interval</h3>
     <div class="timeToggle">

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -107,7 +107,7 @@ date_stampLastWeek: {date_stamp}
     {% render "graph-section" path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png", title: "First Response For Closed PR" %}
     <!--- Line Complexity Graphs -->
     {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg", title: "Line Complexity" %}
-    <!--- Time Toggle Testing -->
+    <!--- New Commit Contributors by Day over Last Month and Last 6 Months -->
       {% assign optionsArray = '1 Month, 6 Month' | split: ',' %}
       {% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}
       {% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -100,15 +100,15 @@ date_stampLastWeek: {date_stamp}
   <h2>Activity Graphs</h2>
   <div class="all-graphs">
     <!--- Issues/PRs Status Breakdown Graph -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg", title: "Issues & PRs Status Breakdown" %}
+    {{% render "graph-section"  baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/issue_gauge_{repo_name}_data.svg", title: "Issues & PRs Status Breakdown" %}}
     <!--- Contributor Activity Line Graph -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg", title: "Commits by Month" %}
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/commit_sparklines_{repo_name}_data.svg", title: "Commits by Month" %}}
     <!--- First Response For Closed PR Scatterplot -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png", title: "First Response For Closed PR" %}
+    {{% render "graph-section" baseurl: site.baseurl, class: "firstResponsePRCrop", path: "/{repo_owner}/{repo_name}/firstResponseForClosedPR_{repo_name}_data.png", title: "First Response For Closed PR" %}}
     <!--- Line Complexity Graphs -->
-    {% render "graph-section" path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg", title: "Line Complexity" %}
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/total_line_makeup_{repo_name}_data.svg", title: "Line Complexity" %}}
     <!--- New Commit Contributors by Day over Last Month and Last 6 Months -->
-      {% assign optionsArray = '1 Month, 6 Month' | split: ',' %}
-      {% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}
-      {% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}
+      {{% assign optionsArray = '1 Month, 6 Month' | split: ',' %}}
+      {{% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}}
+      {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
 </div>


### PR DESCRIPTION
## Reports: Check for File Existence

## Problem

For some repo reports, we won't be able to download a graph if there isn't enough data to generate it. A file existence check is needed to check for missing graphs in the org report template and repo report template.

## Solution

- Created an 11ty filter `fileExists` that uses `fs` to check on whether a file exists in the project directory.
- Created a component called `graph-section.liquid` with path to graph and section title as the parameters. First, it checks the dev file path of the graph which is located in `site/_graphs`. Then, it will display the graph accordingly using the graph path in the `dist` directory (output directory generated by 11ty after building project).
- Added `fileExists` check to `graph-toggle.liquid` as well
- Updated org report and repo report templates using new `graph-section` component

## Result
Graphs are displayed accordingly based on whether graph img exists.

## Test Plan
Waiting