### PR TITLE
Fix Report Colors not Having Correct Color Connotation

### DIFF
--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -87,7 +87,7 @@ def get_heading_report_values(headings, oss_entity):
             if raw_diff < 0:
                 # Red color
                 diff_color = 'color: #d31c08'
-        elif and_conditional or raw_diff < 0:
+        elif and_conditional or (raw_diff < 0 and not and_conditional):
             # Green color
             diff_color = 'color: #45c527'
 
@@ -138,20 +138,24 @@ def generate_org_report_files(orgs):
             "repo_owner": org.login
         }
 
-        org_metric_table_headings = [
-            'commits_count',
-            'issues_count',
-            'open_issues_count',
-            'closed_issues_count',
-            'pull_requests_count',
-            'open_pull_requests_count',
-            'merged_pull_requests_count',
-            'closed_pull_requests_count',
-            'forks_count',
-            'stargazers_count',
-            'watchers_count',
-            'followers_count'
-        ]
+        #Define headings as key value pairs where
+        #   key -> value = heading -> desired_behavior
+        #
+        # DesiredReportBehavior.VALUE_INCREASE means you want the value to go up
+        org_metric_table_headings = {
+            'commits_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'issues_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'open_issues_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'closed_issues_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'pull_requests_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'open_pull_requests_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'merged_pull_requests_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'closed_pull_requests_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'forks_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'stargazers_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'watchers_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'followers_count': DesiredReportBehavior.VALUE_INCREASE.value
+        }
 
         report_values.update(get_heading_report_values(
             org_metric_table_headings, org))

--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -47,7 +47,7 @@ def get_heading_report_values(headings, oss_entity):
     """
 
     report_values = {}
-    for heading, behavior in headings:
+    for heading, behavior in headings.items():
         prev_record = oss_entity.metric_data[heading]
 
         if heading in oss_entity.previous_metric_data.keys():

--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -68,16 +68,16 @@ def get_heading_report_values(headings, oss_entity):
         diff_color = ''
 
 
-#        Truth Table:
-#
-#        +--------------+--------------------------------------+---+-------------------+
-#        | raw_diff > 0 | DesiredReportBehavior.VALUE_INCREASE | _ |      Result       |
-#        +--------------+--------------------------------------+---+-------------------+
-#        |            0 |                                    1 | _ | Red if negative   |
-#        |            1 |                                    0 | _ | Red if negative   |
-#        |            1 |                                    1 |   | Green             |
-#        |            0 |                                    0 | - | Green if negative |
-#        +--------------+--------------------------------------+---+-------------------+
+        #        Truth Table:
+        #
+        #        +--------------+--------------------------------------+---+-------------------+
+        #        | raw_diff > 0 | DesiredReportBehavior.VALUE_INCREASE | _ |      Result       |
+        #        +--------------+--------------------------------------+---+-------------------+
+        #        |            0 |                                    1 | _ | Red if negative   |
+        #        |            1 |                                    0 | _ | Red if negative   |
+        #        |            1 |                                    1 |   | Green             |
+        #        |            0 |                                    0 | - | Green if negative |
+        #        +--------------+--------------------------------------+---+-------------------+
 
 
         and_conditional = (raw_diff > 0 and 

--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -2,7 +2,7 @@
 Module to define methods to create reports
 """
 from datetime import date
-from metricsLib.constants import REPO_REPORT_TEMPLATE, ORG_REPORT_TEMPLATE
+from metricsLib.constants import REPO_REPORT_TEMPLATE, ORG_REPORT_TEMPLATE, DesiredReportBehavior
 
 
 def calc_percent_difference(latest, prev):
@@ -37,8 +37,8 @@ def get_heading_report_values(headings, oss_entity):
     a heading is a type of data point. i.e. commits_diff versus pull_request_count_diff.
 
     Arguments:
-        headings: collection
-            Collection of data point types i.e. 'commits'
+        headings: dictionary
+            dictionary of data point types i.e. 'commits' with desired behavior
         oss_entity: OssEntity
             Data structure representing the entity that the data corresponds to
     
@@ -47,7 +47,7 @@ def get_heading_report_values(headings, oss_entity):
     """
 
     report_values = {}
-    for heading in headings:
+    for heading, behavior in headings:
         prev_record = oss_entity.metric_data[heading]
 
         if heading in oss_entity.previous_metric_data.keys():
@@ -67,12 +67,29 @@ def get_heading_report_values(headings, oss_entity):
 
         diff_color = ''
 
-        if raw_diff > 0:
+
+#        Truth Table:
+#
+#        +--------------+--------------------------------------+---+-------------------+
+#        | raw_diff > 0 | DesiredReportBehavior.VALUE_INCREASE | _ |      Result       |
+#        +--------------+--------------------------------------+---+-------------------+
+#        |            0 |                                    1 | _ | Red if negative   |
+#        |            1 |                                    0 | _ | Red if negative   |
+#        |            1 |                                    1 |   | Green             |
+#        |            0 |                                    0 | - | Green if negative |
+#        +--------------+--------------------------------------+---+-------------------+
+
+
+        and_conditional = (raw_diff > 0 and 
+            (behavior == DesiredReportBehavior.VALUE_INCREASE.value))
+        #Use a XOR by using the != operator
+        if raw_diff > 0 != (behavior == DesiredReportBehavior.VALUE_INCREASE.value):
+            if raw_diff < 0:
+                # Red color
+                diff_color = 'color: #d31c08'
+        elif and_conditional or raw_diff < 0:
             # Green color
             diff_color = 'color: #45c527'
-        elif raw_diff < 0:
-            # Red color
-            diff_color = 'color: #d31c08'
 
         report_values.update({
             f"latest_{heading}": oss_entity.metric_data[heading],
@@ -158,19 +175,23 @@ def generate_repo_report_files(repos):
             "repo_name": repo.name,
         }
 
-        metric_table_headings = [
-            'commits_count',
-            'issues_count',
-            'open_issues_count',
-            'closed_issues_count',
-            'pull_requests_count',
-            'open_pull_requests_count',
-            'merged_pull_requests_count',
-            'closed_pull_requests_count',
-            'forks_count',
-            'stargazers_count',
-            'watchers_count'
-        ]
+        #Define headings as key value pairs where
+        #   key -> value = heading -> desired_behavior
+        #
+        # DesiredReportBehavior.VALUE_INCREASE means you want the value to go up
+        metric_table_headings = {
+            'commits_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'issues_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'open_issues_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'closed_issues_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'pull_requests_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'open_pull_requests_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'merged_pull_requests_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'closed_pull_requests_count': DesiredReportBehavior.VALUE_DECREASE.value,
+            'forks_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'stargazers_count': DesiredReportBehavior.VALUE_INCREASE.value,
+            'watchers_count': DesiredReportBehavior.VALUE_INCREASE.value
+        }
 
         report_values.update(get_heading_report_values(
             metric_table_headings, repo))

--- a/scripts/metricsLib/constants.py
+++ b/scripts/metricsLib/constants.py
@@ -4,6 +4,7 @@ Defines constants for use in metricsLib
 import datetime
 import os
 from pathlib import Path
+from enum import Enum
 
 TIMEOUT_IN_SECONDS = 20
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -29,3 +30,11 @@ with open(template_path, "r", encoding="utf-8") as file:
 
 with open(os.path.join(PATH_TO_TEMPLATES, "org_report_template.md"), "r", encoding="utf-8") as file:
     ORG_REPORT_TEMPLATE = file.read()
+
+class DesiredReportBehavior(Enum):
+    """
+    Enumeration class to define constants for report
+    heading generation behavior
+    """
+    VALUE_INCREASE = 1
+    VALUE_DECREASE = -1


### PR DESCRIPTION
## Fix Report Colors not Having Correct Color Connotation

Closes #73

## Problem

Some key values (such as Open PRs) were displaying as red when their value would go down. This is not the intended behavior for the reports. 

## Solution

Now, each heading in the report has a corresponding desired behavior i.e. commits have a desired behavior of INCREASE because we want to see more commits in the repository. A corresponding enumeration data structure has been created to represent the values of INCREASE and DECREASE.

## Result

Reports generation now takes into account the desired report behavior of each report value when deciding the change in colors. 
