### PR TITLE
Fix Issue with Proper Significant Digits not Being Shown in Reports

### DIFF
--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -17,7 +17,7 @@ def calc_percent_difference(latest, prev):
             old number to compare to new number
 
     Returns:
-        Integer between 0 and 100 corresponding to the percent 
+        Float between 0 and 100 corresponding to the percent 
         difference.
     """
 
@@ -28,7 +28,25 @@ def calc_percent_difference(latest, prev):
     except ZeroDivisionError:
         dec = 0
 
-    return int(dec * 100)
+    return dec * 100
+
+def round_to_significant_figures(n, significant_figures):
+    """
+    Returns the input rounded to the desired number of significant figures
+
+    Arguments:
+        n: number
+
+        significant_figures: int
+            The number of significant figures to round to.
+    
+    Returns:
+        String of the number formatted to the desired number of significant figures.
+    """
+
+    formatted = '{:g}'.format(float('{:.{p}g}'.format(n, p=significant_figures)))
+
+    return formatted
 
 
 def get_heading_report_values(headings, oss_entity):
@@ -78,7 +96,7 @@ def get_heading_report_values(headings, oss_entity):
             f"latest_{heading}": oss_entity.metric_data[heading],
             f"previous_{heading}": prev_record,
             f"{heading}_diff": raw_diff,
-            f"{heading}_diff_percent": percent_difference,
+            f"{heading}_diff_percent": round_to_significant_figures(percent_difference, 2),
             f"{heading}_diff_color": diff_color,
             f"{heading}_diff_percent_color": diff_color
         })


### PR DESCRIPTION
## Fix Issue with Proper Significant Digits not Being Shown in Reports

## Problem

Smaller percentage values in the repo and org reports weren't being displayed properly. If the change percent was less than 10 the proper number of sigificant figures (2) were not being shown. 


<img width="760" alt="image" src="https://github.com/DSACMS/metrics/assets/24639268/c018f681-7bb5-4709-bfa0-c02e9277b47e">

This PR closes #85 

## Solution

Added a method to format the percentage value by casting the float value to a string and using format string methods. This way no extra modules such as math are included.

