### PR TITLE
Fix Error In Report Generation

### DIFF
--- a/scripts/gen_reports.py
+++ b/scripts/gen_reports.py
@@ -98,14 +98,13 @@ def get_heading_report_values(headings, oss_entity):
         #        +--------------+--------------------------------------+---+-------------------+
 
 
-        and_conditional = (raw_diff > 0 and 
-            (behavior == DesiredReportBehavior.VALUE_INCREASE.value))
+        and_conditional = ((raw_diff>0) and (behavior == DesiredReportBehavior.VALUE_INCREASE.value))
         #Use a XOR by using the != operator
-        if raw_diff > 0 != (behavior == DesiredReportBehavior.VALUE_INCREASE.value):
+        if (raw_diff > 0) != (behavior == DesiredReportBehavior.VALUE_INCREASE.value):
             if raw_diff < 0:
                 # Red color
                 diff_color = 'color: #d31c08'
-        elif and_conditional or (raw_diff < 0 and not and_conditional):
+        elif and_conditional or ((raw_diff < 0) and not and_conditional):
             # Green color
             diff_color = 'color: #45c527'
 


### PR DESCRIPTION
## Fix Error in Report Generation

## Problem

There is a missing set of parenthesis in the boolean logic in reports generation to determine whether a number is highlighted green or red. This was causing unintended behavior. 

Below is an example of the unintended evaluation: 

<img width="349" alt="Screenshot 2024-04-09 at 1 27 36 PM" src="https://github.com/DSACMS/metrics/assets/24639268/462f6c34-7bb9-4ba6-9fad-34fb160da6d6">

The problem is hard to spot at first; because of a missing set of parenthesis the inequality operator `!=` was evaluating the numeral `0` instead of `raw_diff > 0`. 
## Solution

Add extra sets of parenthesis to this section of `gen_reports.py`.

## Result

This will result in the desired colors being used to highlight report diffs. 

