### PR TITLE
Format PyGals Line Graph Correctly

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -1,8 +1,8 @@
 """
 Module to define methods to create pygals graphs
 """
+import datetime
 import pygal
-
 
 def generate_all_graphs_for_repos(all_repos):
     """
@@ -76,7 +76,7 @@ def generate_repo_sparklines(repo):
     # are rendered through a special method of the Line object.
     # TODO: file a pygals issue to make sparklines their own object
     _kwargs_ = {
-        "show_x_labels": True,
+        "show_x_labels": False,
         "show_y_labels": True,
         "margin": 10
     }
@@ -96,12 +96,16 @@ def generate_time_xy_issue_graph(oss_entity,data_key,legend_key):
 
     graph_data_dict = oss_entity.metric_data[data_key]
 
-    dates_list = [record[0] for record in graph_data_dict]
-    issues_list = [record[1] for record in graph_data_dict]
+    date_str = '%Y-%m-%dT%H:%M:%SZ'
 
-    xy_time_issue_chart = pygal.Line(x_label_rotation=20)
-    xy_time_issue_chart.x_labels = dates_list
-    xy_time_issue_chart.add(legend_key, issues_list)
+    date_series = []
+    for record in graph_data_dict:
+        date_obj = datetime.datetime.strptime(record[0],date_str)
+        date_series.append((date_obj,record[1]))
+
+    xy_time_issue_chart = pygal.Line(x_label_rotation=20,legend_at_bottom=True,stroke=False)
+    #xy_time_issue_chart.x_labels = dates_list
+    xy_time_issue_chart.add(legend_key, date_series)
 
     write_repo_chart_to_file(oss_entity, xy_time_issue_chart, data_key)
 

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -96,16 +96,16 @@ def generate_time_xy_issue_graph(oss_entity,data_key,legend_key):
 
     graph_data_dict = oss_entity.metric_data[data_key]
 
-    date_str = '%Y-%m-%dT%H:%M:%SZ'
 
     date_series = []
     for record in graph_data_dict:
-        date_obj = datetime.datetime.strptime(record[0],date_str)
-        date_series.append((date_obj,record[1]))
+        #datetime.datetime.fromisoformat(stamp.replace('Z', '+00:00'))
+        date_obj = datetime.datetime.fromisoformat(record[0].replace('Z', '+00:00'))
+        date_series.append((date_obj.strftime('%Y/%m/%d'),record[1]))
 
     xy_time_issue_chart = pygal.Line(x_label_rotation=20,legend_at_bottom=True,stroke=False)
-    #xy_time_issue_chart.x_labels = dates_list
-    xy_time_issue_chart.add(legend_key, date_series)
+    xy_time_issue_chart.x_labels = [iter[0] for iter in date_series]
+    xy_time_issue_chart.add(legend_key, [iter[1] for iter in date_series])
 
     write_repo_chart_to_file(oss_entity, xy_time_issue_chart, data_key)
 

--- a/scripts/refresh_metrics.py
+++ b/scripts/refresh_metrics.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
         tracking_file["orgs"], repo_urls)
 
     # Generate json data, report data, and graph data.
+    #read_previous_metric_data(all_repos,all_orgs)
     get_all_data(all_orgs, all_repos)
     generate_repo_report_files(all_repos)
     generate_org_report_files(all_orgs)


### PR DESCRIPTION
## Format PyGals Line Graph Correctly

## Problem

There are some minor formatting changes needed for the PyGals line graphs we are using:

- The legend is in the wrong place
- The graph should hide its lines
- The date labels should be formatted properly
- Sparklines should not have date labels

## Solution

- Put the legend below the graph
- Made the labels parsed as Python Datetimes
- Formatted the date labels properly
- Removed sparklines date labels

## Result

New sparklines:
![commit_sparklines_dedupliFHIR_data](https://github.com/DSACMS/metrics/assets/24639268/1d918950-9796-43b4-9ab4-2a9e890ae914)


New Line Graph:
![new_commit_contributors_by_day_over_last_month_repo-scaffolder_data](https://github.com/DSACMS/metrics/assets/24639268/7c3807e4-dc4b-4e83-87b8-392ffa5e0e66)

