### PR TITLE
Rollup: Fixed JS files during build process

### DIFF
--- a/app/rollup.config.mjs
+++ b/app/rollup.config.mjs
@@ -5,19 +5,9 @@ import terser from "@rollup/plugin-terser"
 
 export default [
   {
-    input: "src/js/index.js",
+    input: ["src/js/index.js", "src/js/projects.js", "src/js/graphs.js"],
     output: {
-      file: "site/_includes/js/index.js",
-      format: "esm",
-    },
-    input: "src/js/projects.js",
-    output: {
-      file: "site/_includes/js/projects.js",
-      format: "esm",
-    },
-    input: "src/js/graphs.js",
-    output: {
-      file: "site/_includes/js/graphs.js",
+      dir: "site/_includes/js",
       format: "esm",
     },
     plugins: [

--- a/app/site/_includes/nav.liquid
+++ b/app/site/_includes/nav.liquid
@@ -11,7 +11,7 @@
     </div>
     <nav aria-label="Primary navigation" class="usa-nav">
       <button type="button" class="usa-nav__close">
-        <img src="/assets/img/usa-icons/close.svg" role="img" alt="Close">
+        <img src= {{"/assets/img/usa-icons/close.svg" | url}} role="img" alt="Close">
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <li class="usa-nav__primary-item">

--- a/app/site/_includes/nav.liquid
+++ b/app/site/_includes/nav.liquid
@@ -11,7 +11,7 @@
     </div>
     <nav aria-label="Primary navigation" class="usa-nav">
       <button type="button" class="usa-nav__close">
-        <img src= {{"/assets/img/usa-icons/close.svg" | url}} role="img" alt="Close">
+        <img src="{{"/assets/img/usa-icons/close.svg" | url}}" role="img" alt="Close">
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <li class="usa-nav__primary-item">


### PR DESCRIPTION
## Rollup: Fixed JS files during build process

## Problem

In production, `index.js` and `project.js` were files that could not be found on the project build, thus functionalities like project search and display of the US Government website banner did not work. This was due to a incorrect rollup.js configuration.

## Solution

Corrected the rollup.js configuration to include all js files in `src/js`. Also fixed a minor url issue.