### PR TITLE
Commented out gov banner

### DIFF
--- a/app/site/_includes/banner.liquid
+++ b/app/site/_includes/banner.liquid
@@ -12,7 +12,7 @@
     </p>
   </div>
 </div>
-<section
+{% comment %} <section
   class="usa-banner"
   aria-label="Official website of the United States government"
 >
@@ -37,8 +37,7 @@
           aria-expanded="false"
           aria-controls="gov-banner-default-default"
         >
-          {% comment %} TODO: Fix CSS of banner {% endcomment %}
-          {% comment %} <span class="usa-banner__button-text">Here’s how you know</span> {% endcomment %}
+          <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>
     </header>
@@ -101,4 +100,4 @@
       </div>
     </div>
   </div>
-</section>
+</section> {% endcomment %}


### PR DESCRIPTION
## Removed gov banner

## Problem
Currently the website's domain is [dsacms.github.io](https://dsacms.github.io/metrics/), thus is technically not an official government website, so the banner should not be shown on the website for now.

## Solution
Commented out gov banner until the website is on a .gov domain and is an official website!