### PR TITLE
Fix Bug With Unhandled Timeout Exception

### DIFF
--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -173,11 +173,8 @@ class ResourceMetric(BaseMetric):
         return response
 
     def get_values(self,params=None, oss_entity=None):
-        try:
-            r = self.hit_metric(params=params)
-        except TimeoutError as e:
-            print(f"Request timeout out  for metric {self.name}: {e}")
-            return {}
+        
+        r = self.hit_metric(params=params)
 
         path = oss_entity.get_path_to_resource_data(self.name, fmt=self.format)
 

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -173,7 +173,7 @@ class ResourceMetric(BaseMetric):
         return response
 
     def get_values(self,params=None, oss_entity=None):
-        
+
         r = self.hit_metric(params=params)
 
         path = oss_entity.get_path_to_resource_data(self.name, fmt=self.format)

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -155,6 +155,9 @@ class OSSEntity:
         except TimeoutError as e:
             print(f"Timeout for repo {self.name} with metric {metric.name}")
             print(f"Error: {e}")
+        except ConnectionError as e:
+            print(f"Connection error for repo {self.name} with metric {metric.name}")
+            print(f"Error: {e}")
 
 
 class Repository(OSSEntity):

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -149,7 +149,12 @@ class OSSEntity:
         params = self.get_parameters_for_metric(metric)
 
         kwargs['params'] = params
-        self.store_metrics(metric.get_values(*args, **kwargs))
+
+        try:
+            self.store_metrics(metric.get_values(*args, **kwargs))
+        except TimeoutError as e:
+            print(f"Timeout for repo {self.name} with metric {metric.name}")
+            print(f"Error: {e}")
 
 
 class Repository(OSSEntity):


### PR DESCRIPTION
## Fix Bug With Unhandled Timeout Exception

## Problem

The new advanced metrics do not handle TimeoutError correctly with the requests library. Timeout causes error instead of moving on and relying on past data.

https://github.com/DSACMS/metrics/actions/runs/8678054654/job/23794473500


## Solution

Moved the timeout handling to the method used to call all metrics at the base class of both Orgs and Repos.
