### PR TITLE
Stop Unneeded CodeQl Action Triggers on Temporary Git Branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
   push:
+    branches: [ "!push-action/*"]
 
 jobs:
   analyze:


### PR DESCRIPTION
## Stop Unneeded CodeQl Action Triggers on Temporary Git Branches

## Problem

CodeQL Action triggers on temporary branches and the branch is deleted by the time the action triggers. Example:

https://github.com/DSACMS/metrics/actions/runs/8745285591

## Solution

Disallow running CodeQL on any branches that start with the string `"push-action/"`