### PR TITLE
Use new repo-scaffolder workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,11 @@ jobs:
     name: Tier 3 Checks
     runs-on: ubuntu-latest
     steps:
+      - uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows
+        with: 
+          url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3s/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
       - uses: actions/checkout@v4
+      - run: echo $extended_json > repolinter.json
       - uses: newrelic/repolinter-action@v1
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow


### PR DESCRIPTION
## Use new repo-scaffolder workflow

## Problem

The repolinter GitHub action that we are using, [newrelic/repolinter-action@v1](https://github.com/newrelic/repolinter-action), doesn't support the extends keyword that is commonly used in repolinter.json files.

## Solution

Use the newly defined reusable extendJSONFile workflow to extend the JSON to what it would have logically been given that the extends keyword worked. 

