### PR TITLE
Use a Matrix Job Configuration workflow to separate each organization data update operation 

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -37,7 +37,7 @@ jobs:
           git config user.email 'actions@users.noreply.github.com'
           git add -A
           timestamp=$(date -u)
-          git commit -m "update data: ${timestamp}" || exit 0
+          git commit -m "update ${{ matrix.orgs }} data: ${timestamp}" || exit 0
       - name: Push to ${{ github.ref_name }}
         uses: CasperWA/push-protected@v2
         with:

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   update:
+    strategy:
+      matrix: 
+        orgs: ["DSACMS","Enterprise-CMCS","CMS-Enterprise","CMSgov"]
     permissions: write-all
     name: update
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
-      - run: ./update.sh
+      - run: ./update.sh ${{ matrix.orgs }}
         env:
           GITHUB_TOKEN: ${{ secrets.METRICS_GITHUB_TOKEN }}
           AUGUR_HOST: ${{ vars.AUGUR_HOST }}

--- a/scripts/fetch_public_metrics.py
+++ b/scripts/fetch_public_metrics.py
@@ -9,7 +9,7 @@ from metricsLib.metrics_definitions import PERIODIC_METRICS, RESOURCE_METRICS
 from metricsLib.oss_metric_entities import GithubOrg, Repository
 from metricsLib.constants import PATH_TO_METADATA
 
-def parse_tracked_repos_file():
+def parse_tracked_repos_file(org=None):
     """
     Function to parse projects_tracked.json
 
@@ -22,7 +22,13 @@ def parse_tracked_repos_file():
     with open(metadata_path, "r", encoding="utf-8") as file:
         tracking_file = json.load(file)
 
-    # Track specific repositories e.g. ['dsacms.github.io']
+    # Only parse the desired org if an org was passed as an argument
+    if org:
+        repo_urls = {
+            org : tracking_file["Open Source Projects"][org]
+        }
+        return [org], repo_urls
+
     repo_urls = tracking_file["Open Source Projects"]
 
     # Get two lists of objects that will hold all the new metrics

--- a/scripts/refresh_metrics.py
+++ b/scripts/refresh_metrics.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
                     help='The GitHub Org to update data for.')
     args = parser.parse_args()
 
-    orgs_urls, repo_urls = parse_tracked_repos_file()
+    orgs_urls, repo_urls = parse_tracked_repos_file(args.org)
 
     all_orgs, all_repos = parse_repos_and_orgs_into_objects(orgs_urls, repo_urls)
 

--- a/scripts/refresh_metrics.py
+++ b/scripts/refresh_metrics.py
@@ -2,6 +2,7 @@
 Script to run all metrics collection and update operations
 """
 import os
+import argparse
 from fetch_public_metrics import get_all_data, parse_repos_and_orgs_into_objects
 from fetch_public_metrics import parse_tracked_repos_file, read_previous_metric_data
 
@@ -9,6 +10,11 @@ from fetch_public_metrics import parse_tracked_repos_file, read_previous_metric_
 
 if __name__ == "__main__":
     os.umask(0)
+
+    parser = argparse.ArgumentParser(description='Metrics script to update data')
+    parser.add_argument('org', type=str, nargs='?',
+                    help='The GitHub Org to update data for.')
+    args = parser.parse_args()
 
     orgs_urls, repo_urls = parse_tracked_repos_file()
 

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 pwd
 cd scripts
-python3 refresh_metrics.py
+python3 refresh_metrics.py $1


### PR DESCRIPTION
##Use a Matrix Job Configuration workflow to separate each organization data update operation 

## Problem

Previously, all update operations happened in one job before being pushed to the main branch. This used up a lot of GitHub workflow execution time on a single job. 

## Solution

Now, update operations are separated by organization. This makes it so that data is updated when it is done gathering it for a specific repository instead of having to wait for all data to be gathered. This also reduces the execution time burden of these jobs as they are now lesser in execution time. 

## Result

closes #143 

## Test Plan

I have tested it locally but I might test the GitHub workflow further on my fork. 
