### PR TITLE
Check for 200 Response Code For All Metrics

### DIFF
--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -87,7 +87,10 @@ class BaseMetric:
             response = requests.request(
                 self.method, endpoint_to_hit, params=request_params, timeout=TIMEOUT_IN_SECONDS)
         try:
-            response_json = json.loads(response.text)
+            if response.status_code == 200:
+                response_json = json.loads(response.text)
+            else:
+                raise ConnectionError(f"Non valid status code {response.status_code}!")
         except JSONDecodeError:
             response_json = {}
 


### PR DESCRIPTION
## Raise a connection error if status code 200 is not returned

## Problem

Right now we only check status codes for ResourceMetric instead of for all metrics.

## Solution

Raise a connection error in the BaseMetric class's hit_metric method to be handled by the apply_metric_and_store_data method and print the error to stdout. 

