### PR TITLE
Add Maintainers Automation

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,6 @@ on:
     push:
         branches:
             - main
-            - add-maintainers-automation
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,63 @@
+on:
+    push:
+        branches:
+            - main
+            - add-maintainers-automation
+    workflow_dispatch:
+
+jobs:
+    update-contributors:
+        runs-on: ubuntu-latest
+        name: Update contributors info in MAINTAINERS.md
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            # Update contributor list
+            - name: Contribute List
+              uses: akhilmhdh/contributors-readme-action@v2.3.10
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  # https://github.com/marketplace/actions/contribute-list#optional-parameters
+                  readme_path: MAINTAINERS.md
+                  use_username: false
+                  commit_message: "BOT: Update contributors info in MAINTAINERS.md"
+
+            # Update contributor count
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Pull changes from contributors-readme-action
+              run: |
+                  git pull
+
+            - name: Get repository contributors count
+              id: get_contributors
+              # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-contributors
+              # https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection
+              # https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#communicating-with-graphql
+              # CANNOT have newlines!
+              run: |
+                  OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+                  REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
+                  QUERY='query { repository(owner: \"'"$OWNER"'\", name: \"'"$REPO"'\") { collaborators { totalCount } } }'
+                  CONTRIBUTORS=$(curl -s -X POST -H "Authorization: bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"query\": \"$QUERY\"}" https://api.github.com/graphql | jq -r '.data.repository.collaborators.totalCount')
+                  echo "Total contributors: $CONTRIBUTORS"
+                  echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+
+            - name: Replace slug in MAINTAINERS.md with number of contributors
+              # https://stackoverflow.com/questions/10613643/replace-a-unknown-string-between-two-known-strings-with-sed
+              run: |
+                  CONTRIBUTORS=${{ steps.get_contributors.outputs.contributors }}
+                  sed -i 's/<!--CONTRIBUTOR COUNT START-->.*<!--CONTRIBUTOR COUNT END-->/<!--CONTRIBUTOR COUNT START--> '"$CONTRIBUTORS"' <!--CONTRIBUTOR COUNT END-->/g' MAINTAINERS.md
+
+            - name: Commit and push changes
+              # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+              # commit changes, but if no changes exist, then exit cleanly
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add MAINTAINERS.md
+                  git commit -m "BOT: Update contributors info in MAINTAINERS.md" || exit 0
+                  git push

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,7 @@
 # Maintainers
 
+Total number of contributors: <!--CONTRIBUTOR COUNT START--><!--CONTRIBUTOR COUNT END-->
+
 MAINTAINERS:
 
 - GITHUB_ID
@@ -24,3 +26,9 @@ reviewers:
 | reviewer     | review contributions from other members | history of review and authorship in a subproject | MAINTAINERS file reviewer entry, and GitHub Org Triage Team|
 | approver     | approve accepting contributions | highly experienced and active reviewer + contributor to a subproject  | MAINTAINERS file approver entry and GitHub Triage Team |
 | lead         | set direction and priorities for a subproject | demonstrated responsibility and excellent technical judgement for the subproject |  MAINTAINERS file owner entry and GitHub Org Admin Team|
+
+## All Contributors
+
+<!-- readme: contributors -start -->
+
+<!-- readme: contributors -end -->

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--><!--CONTRIBUTOR COUNT END-->
+Total number of contributors: <!--CONTRIBUTOR COUNT START--> 3 <!--CONTRIBUTOR COUNT END-->
 
 MAINTAINERS:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,5 +30,38 @@ reviewers:
 ## All Contributors
 
 <!-- readme: contributors -start -->
-
+<table>
+	<tbody>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/IsaacMilarky">
+                    <img src="https://avatars.githubusercontent.com/u/24639268?v=4" width="100;" alt="IsaacMilarky"/>
+                    <br />
+                    <sub><b>Isaac Milarsky</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/natalialuzuriaga">
+                    <img src="https://avatars.githubusercontent.com/u/29980737?v=4" width="100;" alt="natalialuzuriaga"/>
+                    <br />
+                    <sub><b>Natalia Luzuriaga</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/navila-luna">
+                    <img src="https://avatars.githubusercontent.com/u/52260794?v=4" width="100;" alt="navila-luna"/>
+                    <br />
+                    <sub><b>Nicole Avila</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/decause-gov">
+                    <img src="https://avatars.githubusercontent.com/u/107957201?v=4" width="100;" alt="decause-gov"/>
+                    <br />
+                    <sub><b>decause-gov</b></sub>
+                </a>
+            </td>
+		</tr>
+	<tbody>
+</table>
 <!-- readme: contributors -end -->


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Add Maintainers Automation

## Problem

Currently, the Maintainers.md file is empty.

## Solution

This PR adds a Github Action automated script that populates the
maintainers.md file with the total count of contributors and a table of
everyone who has contributed to the repository previously.
