### PR TITLE
Add Top Committer by Org Graph

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -33,6 +33,7 @@ def generate_all_graphs_for_orgs(all_orgs):
         generate_solid_gauge_issue_graph(org)
         generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_six_months", "New Issues")
         generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_month", "New Issues")
+        generate_top_committer_bar_graph(org)
 
 
 def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_func_params={}):
@@ -187,3 +188,28 @@ def generate_solid_gauge_issue_graph(oss_entity):
             {'label': "Closed Pull Requests", 'value': closed_pr_percent * 100, 'max_value': 100}])
 
     write_repo_chart_to_file(oss_entity, issues_gauge, "issue_gauge")
+
+def generate_top_committer_bar_graph(oss_entity):
+    """
+    This function generates pygals -top committer by org- bar graph.
+
+    Arguments:
+        oss_entity: the OSSEntity to create a graph for.
+    """
+    
+    # Create a bar chart object
+    bar_chart = pygal.Bar()
+    bar_chart.title = f"Top Committers in {oss_entity.metric_data['name']}"
+
+    top_committers = oss_entity.metric_data['top_committers']
+    contributor_count = 0
+
+    for committer, commits in top_committers:
+        if "dependabot" in committer:
+            continue
+        if contributor_count == 5:
+            break
+        bar_chart.add(committer, commits)
+        contributor_count += 1
+
+    write_repo_chart_to_file(oss_entity, bar_chart, "top_committers")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -205,7 +205,7 @@ def generate_top_committer_bar_graph(oss_entity):
     contributor_count = 0
 
     for committer, commits in top_committers:
-        if "dependabot" in committer:
+        if "dependabot" in committer or committer == "actions@github.com":
             continue
         if contributor_count == 5:
             break

--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -109,5 +109,7 @@ date_stampLastWeek: {date_stamp}
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_issue_gauge.svg", title: "Issues & PRs Status Breakdown" %}}
     <!-- New Issues over Last 6 Months -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg", title: "New Issues over Last 6 Months" %}}
+    <!-- Top Committers Bar Graph -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_top_committers.svg", title: "Top Committers" %}}
   </div>
 </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Add Top Committer by Org Graph

## Problem

We have the API endpoint for the top committers for each org, but no graphic to present the information.

## Solution

Generated a bar graph displaying the top 5 committers for each org.

## Test Plan

In your virtual environment, run `./gen_graphs.sh` to generate new graphic. An svg should be saved as `app/site/_graphs/<org>/<org>_top_committers.svg`. Then run `./gen_reports.sh` to update and render graphic to org metrics site.