### PR TITLE
Add age of project statistic

### DIFF
--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -30,6 +30,7 @@ query ($repo: String!, $owner: String!) {
     forkCount,
     forkingAllowed,
     stargazerCount,
+    createdAt,
     
     pullRequests(first: 1)
     {
@@ -95,7 +96,8 @@ github_graphql_simple_counts_metric_map = {
     "closed_pull_requests_count": ["data", "repository", "closedPullRequests", "totalCount"],
     "forks_count": ["data", "repository", "forkCount"],
     "stargazers_count": ["data", "repository", "stargazerCount"],
-    "watchers_count": ["data", "repository", "watchers", "totalCount"]
+    "watchers_count": ["data", "repository", "watchers", "totalCount"],
+    "created_at": ["data", "repository", "createdAt"]
 }
 SIMPLE_METRICS.append(GraphQLMetric("githubGraphqlSimpleCounts", ["repo", "owner"],
                                     REPO_GITHUB_GRAPHQL_QUERY,


### PR DESCRIPTION
Signed-off-by: Brandon Yee <6111102+Firebird1029@users.noreply.github.com>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Add age of project statistic

## Problem

Currently, the metrics site lacks an age of project statistic.

## Solution

This PR adds the age of project statistic.
