### PR TITLE
Predominant Languages - Add repository language metric

### DIFF
--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -23,6 +23,9 @@ ORG_METRICS = []
 # Metrics that save a resource to a file
 RESOURCE_METRICS = []
 
+# Predominant Languages Endpoint (ex. https://api.github.com/repos/chaoss/augur/languages)
+LANGUAGE_ENDPOINT = "https://api.github.com/repos/chaoss/augur/languages"
+
 REPO_GITHUB_GRAPHQL_QUERY = """
 query ($repo: String!, $owner: String!) {
   repository(name: $repo, owner: $owner) {
@@ -115,6 +118,16 @@ SIMPLE_METRICS.append(RangeMetric("totalRepoBlankLines",["repo_id"], AUGUR_HOST 
                                  "/complexity/project_blank_lines?repo_id={repo_id}",
                                  {"total_project_blank_lines": ["blank_lines"],
                                  "average_blank_lines": ["avg_blank_lines"]}))
+
+SIMPLE_METRICS.append(ListMetric("repositoryLanguages", 
+                                 ["owner", "repo"], 
+                                 LANGUAGE_ENDPOINT, 
+                                 {"languages": None}, 
+                                 token=TOKEN))
+
+SIMPLE_METRICS.append(GraphQLMetric("githubGraphqlSimpleCounts", ["repo", "owner"],
+                                    REPO_GITHUB_GRAPHQL_QUERY,
+                                    github_graphql_simple_counts_metric_map, token=TOKEN))
 
 REPOMETRICS_ENDPOINT = "https://raw.githubusercontent.com/{owner}/{repo}/main/code.json"
 repometrics_values = {"project_type": "project_type", "user_input": "user_input", "project_fisma_level": "project_fisma_level", 


### PR DESCRIPTION
## Predominant Languages - Add repository language metric

## Problem

We would like to fetch data on predominant languages of a repository using the GitHub API.

## Solution

I used the GitHub API to fetch data on predominant languages of a repository and added this info to `metrics_definitions.py`.

## Result

The languages checkpoint has been added and should be accessible.

**Edit: Old PR, look at new version**
