### PR TITLE
Predominant Languages - Add repository language metric

### DIFF
--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -511,3 +511,39 @@ def parse_commits_by_month(**kwargs):
             commits_by_month[month] = 1
 
     return {"commits_by_month": commits_by_month}
+
+class LanguageMetric(BaseMetric):
+    """
+    Class to fetch and process language data for a GitHub repository.
+    ...
+    
+    This class overrides the get_values method to handle the GitHub API's
+    language endpoint, which returns a dictionary of languages and their 
+    byte counts. It calculates the percentage of each language based on 
+    the total bytes of code in the repository.
+
+    Attributes
+    ----------
+        Inherits all attributes from BaseMetric.
+
+    Methods
+    ----------
+        get_values(params=None): Fetches language data and calculates
+        percentages.
+    """
+    def __init__(self, name, params, url, token=None):
+        super().__init__(name, params, url, {}, token)
+
+    def get_values(self, params=None):
+        languages_data = self.hit_metric(params=params)
+        total_bytes = sum(languages_data.values())
+        
+        language_percentages = {}
+        for lang, bytes_count in languages_data.items():
+            if total_bytes > 0:
+                percentage = (bytes_count / total_bytes) * 100
+            else:
+                percentage = 0
+            language_percentages[lang] = percentage
+        
+        return {"languages": language_percentages}

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -535,15 +535,5 @@ class LanguageMetric(BaseMetric):
         super().__init__(name, params, url, {}, token)
 
     def get_values(self, params=None):
-        languages_data = self.hit_metric(params=params)
-        total_bytes = sum(languages_data.values())
-        
-        language_percentages = {}
-        for lang, bytes_count in languages_data.items():
-            if total_bytes > 0:
-                percentage = (bytes_count / total_bytes) * 100
-            else:
-                percentage = 0
-            language_percentages[lang] = percentage
-        
-        return {"languages": language_percentages}
+        predom_langs_data = self.hit_metric(params=params)
+        return {"predominant_langs": predom_langs_data}

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -23,6 +23,9 @@ ORG_METRICS = []
 # Metrics that save a resource to a file
 RESOURCE_METRICS = []
 
+# Predominant Languages Endpoint (ex. https://api.github.com/repos/chaoss/augur/languages)
+LANGUAGE_ENDPOINT = "https://api.github.com/repos/chaoss/augur/languages"
+
 REPO_GITHUB_GRAPHQL_QUERY = """
 query ($repo: String!, $owner: String!) {
   repository(name: $repo, owner: $owner) {
@@ -115,6 +118,16 @@ SIMPLE_METRICS.append(RangeMetric("totalRepoBlankLines",["repo_id"], AUGUR_HOST 
                                  "/complexity/project_blank_lines?repo_id={repo_id}",
                                  {"total_project_blank_lines": ["blank_lines"],
                                  "average_blank_lines": ["avg_blank_lines"]}))
+
+SIMPLE_METRICS.append(ListMetric("repositoryLanguages", 
+                                 ["owner", "repo"], 
+                                 LANGUAGE_ENDPOINT, 
+                                 {"languages": None}, 
+                                 token=TOKEN))
+
+SIMPLE_METRICS.append(GraphQLMetric("githubGraphqlSimpleCounts", ["repo", "owner"],
+                                    REPO_GITHUB_GRAPHQL_QUERY,
+                                    github_graphql_simple_counts_metric_map, token=TOKEN))
 
 REPOMETRICS_ENDPOINT = "https://raw.githubusercontent.com/{owner}/{repo}/main/code.json"
 repometrics_values = {"project_type": "project_type", "user_input": "user_input", "project_fisma_level": "project_fisma_level", 

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -4,7 +4,7 @@ Definitions of specific metrics for metricsLib
 from metricsLib.metrics_data_structures import CustomMetric, parse_commits_by_month, RangeMetric
 from metricsLib.metrics_data_structures import GraphQLMetric, LengthMetric, ResourceMetric, BaseMetric
 from metricsLib.metrics_data_structures import ListMetric, parse_nadia_label_into_badge
-from metricsLib.metrics_data_structures import BaseMetric
+from metricsLib.metrics_data_structures import BaseMetric, LanguageMetric
 from metricsLib.constants import TOKEN, AUGUR_HOST
 
 # The general procedure is to execute all metrics against all repos and orgs
@@ -24,7 +24,7 @@ ORG_METRICS = []
 RESOURCE_METRICS = []
 
 # Predominant Languages Endpoint (ex. https://api.github.com/repos/chaoss/augur/languages)
-LANGUAGE_ENDPOINT = "https://api.github.com/repos/chaoss/augur/languages"
+LANGUAGE_ENDPOINT = "https://api.github.com/repos/{owner}/{repo}/languages"
 
 REPO_GITHUB_GRAPHQL_QUERY = """
 query ($repo: String!, $owner: String!) {
@@ -119,11 +119,10 @@ SIMPLE_METRICS.append(RangeMetric("totalRepoBlankLines",["repo_id"], AUGUR_HOST 
                                  {"total_project_blank_lines": ["blank_lines"],
                                  "average_blank_lines": ["avg_blank_lines"]}))
 
-SIMPLE_METRICS.append(ListMetric("repositoryLanguages", 
-                                 ["owner", "repo"], 
-                                 LANGUAGE_ENDPOINT, 
-                                 {"languages": None}, 
-                                 token=TOKEN))
+SIMPLE_METRICS.append(LanguageMetric("repositoryLanguages", 
+                                     ["owner", "repo"], 
+                                     LANGUAGE_ENDPOINT, 
+                                     token=TOKEN))
 
 SIMPLE_METRICS.append(GraphQLMetric("githubGraphqlSimpleCounts", ["repo", "owner"],
                                     REPO_GITHUB_GRAPHQL_QUERY,


### PR DESCRIPTION
## Predominant Languages - Add repository language metric

## Problem

We would like to fetch data on predominant languages of a repository using the GitHub API.

## Solution

I used the GitHub API to fetch data on predominant languages of a repository and added this info to `metrics_definitions.py`.

## Result

The languages checkpoint has been added and should be accessible.