### PR TITLE
chore: Update SECURITY.md to add new VDP

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,8 @@
 # Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
-email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
-HHS maintains an acknowledgements page to recognize your efforts on behalf of
-the American public, but you are also welcome to submit anonymously.
+The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
+
+*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 Review the HHS Disclosure Policy and websites in scope:
 [https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
@@ -14,4 +12,4 @@ policy, *how to send* us vulnerability reports, and *how long* we ask security
 researchers to wait before publicly disclosing vulnerabilities.
 
 If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov.](mailto:csirc@hhs.gov).
+[csirc@hhs.gov](mailto:csirc@hhs.gov).


### PR DESCRIPTION
## SECURITY.md: New VDP policy

## Problem

The CMS VDP has been updated to reflect the launch of our new bug bounty program! As a result, SECURITY.md needs to be updated accordingly.

## Solution

Updated SECURITY.md using the repo-scaffolder "Adding Files" GitHub action:
https://www.cms.gov/about-cms/information-systems/privacy/vulnerability-disclosure-policy