### PR TITLE
added predominant language graph to repo pages

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -217,3 +217,27 @@ def generate_top_committer_bar_graph(oss_entity):
         contributor_count += 1
 
     write_repo_chart_to_file(oss_entity, bar_chart, "top_committers")
+
+def generate_predominant_languages_graph(oss_entity):
+    """
+    This function generates a pygal predominant programming languages guage graph.
+
+    Arguments:
+        oss_entity: the OSSEntity to create a graph for.
+    """
+
+    guage_graph = pygal.Gauge(dynamic_print_values=True, human_readable = True)
+    graph.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
+
+    predominant_lang = oss_entity.metric_data['predominant_langs']
+    max_amount = 0
+
+    for lang, lines in predominant_lang:
+        if lines > max_amount:
+            max_amount = lines
+
+        graph.add(lang, lines)
+
+    guage_graph.range = [round(max_amount + 2000), 0]
+
+    write_repo_chart_to_file(oss_entity, graph, "predominant_langs")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -16,6 +16,7 @@ def generate_all_graphs_for_repos(all_repos):
         print(f"Generating graphs for repo {repo.name}")
         generate_solid_gauge_issue_graph(repo)
         generate_repo_sparklines(repo)
+        generate_predominant_languages_graph(repo)
         try:
             generate_donut_graph_line_complexity_graph(repo)
             generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_month", "New Contributors")
@@ -38,7 +39,6 @@ def generate_all_graphs_for_orgs(all_orgs):
         generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_six_months", "New Issues")
         generate_time_xy_issue_graph(org, "new_issues_by_day_over_last_month", "New Issues")
         generate_top_committer_bar_graph(org)
-
 
 def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_func_params={}):
     """
@@ -227,7 +227,7 @@ def generate_predominant_languages_graph(oss_entity):
     """
 
     guage_graph = pygal.Gauge(dynamic_print_values=True, human_readable = True)
-    graph.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
+    guage_graph.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
 
     predominant_lang = oss_entity.metric_data['predominant_langs']
     max_amount = 0
@@ -236,8 +236,8 @@ def generate_predominant_languages_graph(oss_entity):
         if lines > max_amount:
             max_amount = lines
 
-        graph.add(lang, lines)
+        guage_graph.add(lang, lines)
 
     guage_graph.range = [round(max_amount + 2000), 0]
 
-    write_repo_chart_to_file(oss_entity, graph, "predominant_langs")
+    write_repo_chart_to_file(oss_entity, guage_graph, "predominant_langs")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -226,18 +226,12 @@ def generate_predominant_languages_graph(oss_entity):
         oss_entity: the OSSEntity to create a graph for.
     """
 
-    guage_graph = pygal.Gauge(dynamic_print_values=True, human_readable = True)
-    guage_graph.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
+    bar_chart = pygal.Bar()
+    bar_chart.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
 
     predominant_lang = oss_entity.metric_data['predominant_langs']
-    max_amount = 0
+    
+    for lang, lines in predominant_lang.items():
+        bar_chart.add(lang, lines)
 
-    for lang, lines in predominant_lang:
-        if lines > max_amount:
-            max_amount = lines
-
-        guage_graph.add(lang, lines)
-
-    guage_graph.range = [round(max_amount + 2000), 0]
-
-    write_repo_chart_to_file(oss_entity, guage_graph, "predominant_langs")
+    write_repo_chart_to_file(oss_entity, bar_chart, "predominant_langs")

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -111,4 +111,6 @@ date_stampLastWeek: {date_stamp}
       {{% assign optionsArray = '1 Month, 6 Month' | split: ',' %}}
       {{% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}}
       {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
+    <!-- Predominant Lanugages Graph -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg", title: "Predominant Languages" %}}
 </div>


### PR DESCRIPTION
## Predominant Languages Frontend

## Problem

Frontend for predominant languages for a repository hasn't been created.

## Solution

Created a bar graph using Pygal to implement the missing field.

## Result

Bar graph showing predominant languages appears on frontend.

## Test Plan

Ran on a venv and went through scripts to test validity 
