### PR TITLE
Create Graph for DRYness Percentage 

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -25,6 +25,7 @@ def generate_all_graphs_for_repos(all_repos):
         except KeyError as e:
             print(f"Could not find metrics to build graphs for repo {repo.name}")
             print(e)
+        generate_dryness_percentage_graph(repo)
 
 
 def generate_all_graphs_for_orgs(all_orgs):
@@ -276,3 +277,22 @@ def generate_dryness_percentage_graph(oss_entity):
     DRY = Don't repeat yourself
     WET = Waste Everybody's time or Write Everything Twice 
     """
+
+    dryness_values = parse_cocomo_dryness_metrics(
+        oss_entity.metric_data["cocomo"]['dryness_table']
+    )
+
+
+    pie_chart = pygal.Pie(half_pie=True)
+    pie_chart.title = 'DRYness Percentage Graph'
+
+    pie_chart.add(
+        'Total Unique Lines of Code (ULOC)', dryness_values['total_uloc']
+    )
+
+    pie_chart.add(
+        'Total Source Lines of Code (SLOC)', 
+        dryness_values['total_uloc'] / dryness_values['DRYness_percentage']
+    )
+    
+    write_repo_chart_to_file(oss_entity, pie_chart, "DRYness")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -2,8 +2,8 @@
 Module to define methods to create pygals graphs
 """
 import datetime
-import pygal
 import re
+import pygal
 
 def generate_all_graphs_for_repos(all_repos):
     """
@@ -20,12 +20,16 @@ def generate_all_graphs_for_repos(all_repos):
         generate_predominant_languages_graph(repo)
         try:
             generate_donut_graph_line_complexity_graph(repo)
-            generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_month", "New Contributors")
-            generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_six_months", "New Contributors")
+            generate_time_xy_issue_graph(
+                repo, "new_commit_contributors_by_day_over_last_month", "New Contributors"
+            )
+            generate_time_xy_issue_graph(
+                repo, "new_commit_contributors_by_day_over_last_six_months", "New Contributors"
+            )
         except KeyError as e:
             print(f"Could not find metrics to build graphs for repo {repo.name}")
             print(e)
-        
+
         try:
             generate_dryness_percentage_graph(repo)
         except ValueError as e:
@@ -210,7 +214,7 @@ def generate_top_committer_bar_graph(oss_entity):
     Arguments:
         oss_entity: the OSSEntity to create a graph for.
     """
-    
+
     # Create a bar chart object
     bar_chart = pygal.Bar()
     bar_chart.title = f"Top Committers in {oss_entity.metric_data['name']}"
@@ -240,7 +244,7 @@ def generate_predominant_languages_graph(oss_entity):
     bar_chart.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
 
     predominant_lang = oss_entity.metric_data['predominant_langs']
-    
+
     for lang, lines in predominant_lang.items():
         bar_chart.add(lang, lines)
 
@@ -271,7 +275,7 @@ def parse_cocomo_dryness_metrics(dryness_string):
         if 'DRYness' in line:
             #Use regex to remove all non-numerals from the string
             dryness_metrics['DRYness_percentage'] = re.sub('[^0-9.]','',line)
-    
+
     return dryness_metrics
 
 
@@ -308,11 +312,11 @@ def generate_dryness_percentage_graph(oss_entity):
         'Unique Lines of Code (ULOC) %', uloc_percent
     )
 
-    #Will cause a value error if the dryness value is NaN which can happen. 
+    #Will cause a value error if the dryness value is NaN which can happen.
     pie_chart.add(
         'Source Lines of Code (SLOC) %', 
         #sloc = uloc / DRYness
         sloc_percent
     )
-    
+
     write_repo_chart_to_file(oss_entity, pie_chart, "DRYness")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -3,6 +3,7 @@ Module to define methods to create pygals graphs
 """
 import datetime
 import pygal
+import re
 
 def generate_all_graphs_for_repos(all_repos):
     """
@@ -235,3 +236,43 @@ def generate_predominant_languages_graph(oss_entity):
         bar_chart.add(lang, lines)
 
     write_repo_chart_to_file(oss_entity, bar_chart, "predominant_langs")
+
+def parse_cocomo_dryness_metrics(dryness_string):
+    """
+    This function parses the output of the scc dryness metrics.
+
+    For some reason, ULOC, SLOC, and DRYness don't show up in the json and
+    only show up in the stdout text.
+
+    Arguments:
+        dryness_string: the string containing the dryness table to parse
+    
+    Returns:
+        A dictionary with the unique lines of code and DRYness percentage
+    """
+
+    dryness_metrics = {}
+
+    for line in dryness_string.split('\n'):
+        if 'Unique Lines of Code' in line:
+            dryness_metrics['total_uloc'] = re.sub('[^0-9.]','',line)
+        if 'DRYness' in line:
+            dryness_metrics['DRYness_percentage'] = re.sub('[^0-9.]','',line)
+    
+    #sloc = uloc / DRYness
+    return dryness_metrics
+
+
+
+
+def generate_dryness_percentage_graph(oss_entity):
+    """
+    This function generates a pygal DRYness pie graph.
+
+    DRYness = ULOC / SLOC
+
+    WETness = 1 - DRYness
+
+    DRY = Don't repeat yourself
+    WET = Waste Everybody's time or Write Everything Twice 
+    """

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -293,21 +293,26 @@ def generate_dryness_percentage_graph(oss_entity):
         oss_entity.metric_data["cocomo"]['dryness_table']
     )
 
+    sloc = (float(dryness_values['total_uloc']) / float(dryness_values['DRYness_percentage']))
+    sloc_diff = sloc - float(dryness_values['total_uloc'])
+    sloc_percent = (sloc_diff / sloc) * 100
 
-    pie_chart = pygal.Pie(half_pie=True)
+    uloc_percent = (float(dryness_values['total_uloc']) / sloc) * 100
+
+    pie_chart = pygal.Pie(half_pie=True, legend_at_bottom=True)
     pie_chart.title = 'DRYness Percentage Graph'
 
     #print(dryness_values)
 
     pie_chart.add(
-        'Total Unique Lines of Code (ULOC)', float(dryness_values['total_uloc'])
+        'Unique Lines of Code (ULOC) %', uloc_percent
     )
 
     #Will cause a value error if the dryness value is NaN which can happen. 
     pie_chart.add(
-        'Total Source Lines of Code (SLOC)', 
+        'Source Lines of Code (SLOC) %', 
         #sloc = uloc / DRYness
-        float(dryness_values['total_uloc']) / float(dryness_values['DRYness_percentage'])
+        sloc_percent
     )
     
     write_repo_chart_to_file(oss_entity, pie_chart, "DRYness")

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -39,7 +39,6 @@ def generate_all_graphs_for_repos(all_repos):
             print(f"Could not find metrics to build dryness graphs for repo {repo.name}")
             print(e)
 
-
 def generate_all_graphs_for_orgs(all_orgs):
     """
     Function to iterate through all orgs and generate graphs for each of them
@@ -76,7 +75,6 @@ def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_f
             print(
                 f"Repo {repo.name} has a division by zero error when trying to make graph")
     # issues_gauge.render_to_file(repo.get_path_to_graph_data("issue_gauge"))
-
 
 def generate_repo_sparklines(repo):
     """
@@ -128,7 +126,6 @@ def generate_time_xy_issue_graph(oss_entity,data_key,legend_key):
 
     write_repo_chart_to_file(oss_entity, xy_time_issue_chart, data_key)
 
-
 def generate_donut_graph_line_complexity_graph(oss_entity):
     """
     This function generates pygals line complexity donut graph
@@ -155,7 +152,6 @@ def generate_donut_graph_line_complexity_graph(oss_entity):
     donut_lines_graph.add('Total Other Lines', num_remaining_lines)
 
     write_repo_chart_to_file(oss_entity, donut_lines_graph, "total_line_makeup")
-
 
 def generate_solid_gauge_issue_graph(oss_entity):
     """
@@ -277,9 +273,6 @@ def parse_cocomo_dryness_metrics(dryness_string):
             dryness_metrics['DRYness_percentage'] = re.sub('[^0-9.]','',line)
 
     return dryness_metrics
-
-
-
 
 def generate_dryness_percentage_graph(oss_entity):
     """

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -111,6 +111,8 @@ date_stampLastWeek: {date_stamp}
       {{% assign optionsArray = '1 Month, 6 Month' | split: ',' %}}
       {{% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}}
       {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
-    <!-- Predominant Lanugages Graph -->
+    <!-- Predominant Languages Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg", title: "Predominant Languages" %}}
+    <!-- DRYness Percentages Graph -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/DRYness_{repo_name}_data.svg", title: "DRYness Percentage Graph" %}}
 </div>


### PR DESCRIPTION
## Create Graph for DRYness Percentage 

## Problem

We have yet to create visualizations for all of our COCOMO metrics, specifically the DRYness percentage. 

DRYness is a measure of how much a project is adhering to DRY (Don't Repeat Yourself) principles. 

DRYness = ULOC / SLOC

ULOC = Unique Lines of Code
SLOC = Source Lines of Code

More info about DRYness can be found here:

- https://github.com/boyter/scc?tab=readme-ov-file#unique-lines-of-code-uloc
- https://lobste.rs/s/has9r7/uloc_unique_lines_code

## Solution

Implement a visualization of the DRYness percentage using a half pie chart.

## Result
![DRYness_dedupliFHIR_data](https://github.com/user-attachments/assets/e0b38d72-0ef8-430c-8287-d2731b17395e)


Summary:

* Add a method to parse the output of the scc dryness option 
* Add a method to parse the dryness values into a pie chart
* Handle edge case where dryness value is NaN
* Added dryness graph to repository metrics template file.
* Fixed minor typo in metrics template file

## Test Plan

I have tested locally.
