### PR TITLE
Added Age of Project to Frontend

### DIFF
--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -1,7 +1,22 @@
 ---
 layout: base
 ---
+<script>
+  function toggleDateAge(element) {
+    const dateSpan = element.querySelector(".date");
+    const ageSpan = element.querySelector(".age");
+  
+    if (ageSpan.style.display === "none") {
+      dateSpan.style.display = "none";
+      ageSpan.style.display = "inline";
+    } else {
+      dateSpan.style.display = "inline";
+      ageSpan.style.display = "none";
+    }
+  }
+</script>
 <script src="{{ "/assets/js/graphs.js" | url }}"></script>
+
 <div class="grid-container">
   {% assign project = projects | findObject: repo %}
 
@@ -172,13 +187,18 @@ layout: base
           </div>
           <p onclick="toggleDateAge(this)" style="cursor: pointer;">
             <span class="date">
-              {{ project.created_at | date: "%B %d, %Y" }}
+              {{ project.created_at | date: '%B %d, %Y' }}
             </span>
             <span class="age" style="display: none;">
-              {% assign created_date = project.created_at | date: "%s" | plus: 0 %}
-              {% assign current_date = "now" | date: "%s" | plus: 0 %}
+              {% comment %} takes project created + todays date and turns it into seconds {% endcomment %}
+              {% assign created_date = project.created_at | date: '%s' | plus: 0 %}
+              {% assign current_date = 'now' | date: '%s' | plus: 0 %}
+
               {% assign age_seconds = current_date | minus: created_date %}
+
+              {% comment %} divide by how many seconds are in a day to convert back into days {% endcomment %}
               {% assign age_days = age_seconds | divided_by: 86400.0 | round %}
+
               {{ age_days }} day{% if age_days != 1 %}s{% endif %}
             </span>
           </p>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -155,6 +155,34 @@ layout: base
           </div>
           <p>{{ project.pull_requests_count }}</p>
         </div>
+        <div class="stat-container" id="project-age">
+          <div class="project-age-heading">
+            <h4>
+              <span>
+                <svg
+                  class="usa-icon"
+                  aria-labelledby="project-age"
+                  role="img"
+                >
+                  {% lucide "calendar" %}
+                </svg>
+              </span>
+              Age Of Project
+            </h4>
+          </div>
+          <p onclick="toggleDateAge(this)" style="cursor: pointer;">
+            <span class="date">
+              {{ project.created_at | date: "%B %d, %Y" }}
+            </span>
+            <span class="age" style="display: none;">
+              {% assign created_date = project.created_at | date: "%s" | plus: 0 %}
+              {% assign current_date = "now" | date: "%s" | plus: 0 %}
+              {% assign age_seconds = current_date | minus: created_date %}
+              {% assign age_days = age_seconds | divided_by: 86400.0 | round %}
+              {{ age_days }} day{% if age_days != 1 %}s{% endif %}
+            </span>
+          </p>
+        </div>
       </div>
     {% else %}
       <p>Error Occurred: Object Not Found</p>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -3,14 +3,14 @@ layout: base
 ---
 <script>
   function toggleDateAge(element) {
-    const dateElements = element.querySelectorAll(".date");
-    const ageElements = element.querySelectorAll(".age");
+    const dateElements = element.querySelectorAll('.date');
+    const ageElements = element.querySelectorAll('.age');
   
-    dateElements.forEach(element => {
+    dateElements.forEach((element) => {
       element.style.display = element.style.display === 'none' ? 'inline' : 'none';
     });
   
-    ageElements.forEach(element => {
+    ageElements.forEach((element) => {
       element.style.display = element.style.display === 'none' ? 'inline' : 'none';
     });
   }
@@ -186,7 +186,7 @@ layout: base
               <span class="age" style="display: none;">Age of Project</span>
             </h4>
           </div>
-          <p style= "text-decoration: underline;">
+          <p style="text-decoration: underline;">
             <span class="date">
               {{ project.created_at | date: '%B %d, %Y' }}
             </span>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -3,16 +3,16 @@ layout: base
 ---
 <script>
   function toggleDateAge(element) {
-    const dateSpan = element.querySelector(".date");
-    const ageSpan = element.querySelector(".age");
+    const dateElements = element.querySelectorAll(".date");
+    const ageElements = element.querySelectorAll(".age");
   
-    if (ageSpan.style.display === "none") {
-      dateSpan.style.display = "none";
-      ageSpan.style.display = "inline";
-    } else {
-      dateSpan.style.display = "inline";
-      ageSpan.style.display = "none";
-    }
+    dateElements.forEach(element => {
+      element.style.display = element.style.display === 'none' ? 'inline' : 'none';
+    });
+  
+    ageElements.forEach(element => {
+      element.style.display = element.style.display === 'none' ? 'inline' : 'none';
+    });
   }
 </script>
 <script src="{{ "/assets/js/graphs.js" | url }}"></script>
@@ -170,7 +170,7 @@ layout: base
           </div>
           <p>{{ project.pull_requests_count }}</p>
         </div>
-        <div class="stat-container" id="project-age">
+        <div class="stat-container" id="project-age" onclick="toggleDateAge(this)" style="cursor: pointer;">
           <div class="project-age-heading">
             <h4>
               <span>
@@ -182,10 +182,11 @@ layout: base
                   {% lucide "calendar" %}
                 </svg>
               </span>
-              Age Of Project
+              <span class="date">Project Creation Date</span>
+              <span class="age" style="display: none;">Age of Project</span>
             </h4>
           </div>
-          <p onclick="toggleDateAge(this)" style="cursor: pointer;">
+          <p style= "text-decoration: underline;">
             <span class="date">
               {{ project.created_at | date: '%B %d, %Y' }}
             </span>

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -5,11 +5,11 @@ layout: base
   function toggleDateAge(element) {
     const dateElements = element.querySelectorAll('.date')
     const ageElements = element.querySelectorAll('.age')
-  
+
     dateElements.forEach((element) => {
       element.style.display = element.style.display === 'none' ? 'inline' : 'none'
     })
-  
+
     ageElements.forEach((element) => {
       element.style.display = element.style.display === 'none' ? 'inline' : 'none'
     })

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -3,16 +3,16 @@ layout: base
 ---
 <script>
   function toggleDateAge(element) {
-    const dateElements = element.querySelectorAll('.date');
-    const ageElements = element.querySelectorAll('.age');
+    const dateElements = element.querySelectorAll('.date')
+    const ageElements = element.querySelectorAll('.age')
   
     dateElements.forEach((element) => {
-      element.style.display = element.style.display === 'none' ? 'inline' : 'none';
-    });
+      element.style.display = element.style.display === 'none' ? 'inline' : 'none'
+    })
   
     ageElements.forEach((element) => {
-      element.style.display = element.style.display === 'none' ? 'inline' : 'none';
-    });
+      element.style.display = element.style.display === 'none' ? 'inline' : 'none'
+    })
   }
 </script>
 <script src="{{ "/assets/js/graphs.js" | url }}"></script>

--- a/app/src/js/graphs.js
+++ b/app/src/js/graphs.js
@@ -17,17 +17,3 @@ window.showGraph = function (selectedGraphId, className, buttonName) {
     }
   })
 }
-
-// goes inside includes/js for the time being
-function toggleDateAge(element) {
-  const dateSpan = element.querySelector('.date');
-  const ageSpan = element.querySelector('.age');
-  
-  if (ageSpan.style.display === 'none') {
-    dateSpan.style.display = 'none';
-    ageSpan.style.display = 'inline';
-  } else {
-    dateSpan.style.display = 'inline';
-    ageSpan.style.display = 'none';
-  }
-}

--- a/app/src/js/graphs.js
+++ b/app/src/js/graphs.js
@@ -17,3 +17,17 @@ window.showGraph = function (selectedGraphId, className, buttonName) {
     }
   })
 }
+
+// goes inside includes/js for the time being
+function toggleDateAge(element) {
+  const dateSpan = element.querySelector('.date');
+  const ageSpan = element.querySelector('.age');
+  
+  if (ageSpan.style.display === 'none') {
+    dateSpan.style.display = 'none';
+    ageSpan.style.display = 'inline';
+  } else {
+    dateSpan.style.display = 'inline';
+    ageSpan.style.display = 'none';
+  }
+}


### PR DESCRIPTION
## Added Age of Project to Frontend

## Problem

Age of project was in the backend but wasnt showing on the frontend.

## Solution

Display the age of project field on the frontend as a metric.

## Result

The user can view both the date the repo was created as well as the amount of days it has been since the repo was created. This can be toggled by clicking on the field
![Screen Recording 2024-10-09 at 12 08 04 PM](https://github.com/user-attachments/assets/c5017e4f-ef4f-4669-b2e2-6701f3d3b94c)

Some important notes regarding the summary line:

* Before publishing, i want to confirm designs and learn more about the JS consolidation 

## Test Plan

Tested locally on prod and dev.

