### PR TITLE
Create Graph for Libyears Metric

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -236,7 +236,7 @@ def generate_predominant_languages_graph(oss_entity):
 
     write_repo_chart_to_file(oss_entity, bar_chart, "predominant_langs")
 
-def parse_libyear_dates(dependency_list):
+def parse_libyear_list(dependency_list):
     """
     Parses the dependency list returned from the libyear metric into a list of python dictionaries
     that have correctly parsed dates.
@@ -262,7 +262,8 @@ def parse_libyear_dates(dependency_list):
             }
         )
     
-    return to_return
+    #return list sorted by date
+    return sorted(to_return, key=lambda d : d["libyear_date_last_updated"])
 
 
 def generate_libyears_graph(oss_entity):
@@ -273,13 +274,16 @@ def generate_libyears_graph(oss_entity):
         oss_entity: the OSSEntity to create a libyears graph for.
     """
 
-    dep_list = oss_entity.metric_data['repo_dependency_libyear_list']
-    if not dep_list:
+    raw_dep_list = oss_entity.metric_data['repo_dependency_libyear_list']
+    if not raw_dep_list:
         return
     
     line_chart = pygal.Line()
 
     line_chart.title = 'Dependency Libyears'
 
+    dep_list = parse_libyear_list(raw_dep_list)
+    earliest_year = dep_list[0]["libyear_date_last_updated"].year - 5
+    latest_year = dep_list[-1]["libyear_date_last_updated"].year + 1
 
-    line_chart.x_labels = map(str, range(2002, 2013))
+    line_chart.x_labels = map(str, range(earliest_year, latest_year))

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -25,7 +25,7 @@ def generate_all_graphs_for_repos(all_repos):
         except KeyError as e:
             print(f"Could not find metrics to build graphs for repo {repo.name}")
             print(e)
-        
+
         try:
             generate_libyears_graph(repo)
         except KeyError:
@@ -53,7 +53,7 @@ def generate_all_graphs_for_orgs(all_orgs):
 
 def write_repo_chart_to_file(repo, chart, chart_name, custom_func=None, custom_func_params={}):
     """
-    This function's purpose is to save a pygals chart to a path derived from the 
+    This function's purpose is to save a pygals chart to a path derived from the
     repository object passed in.
 
     Arguments:
@@ -132,7 +132,7 @@ def generate_donut_graph_line_complexity_graph(oss_entity):
     for a set of Repository objects.
 
     Arguments:
-        oss_entity: The OSSEntity to create a graph for. an 
+        oss_entity: The OSSEntity to create a graph for. an
             OSSEntity is a data structure that is typically
             a repository or an organization.
     """
@@ -211,7 +211,7 @@ def generate_top_committer_bar_graph(oss_entity):
     Arguments:
         oss_entity: the OSSEntity to create a graph for.
     """
-    
+
     # Create a bar chart object
     bar_chart = pygal.Bar()
     bar_chart.title = f"Top Committers in {oss_entity.metric_data['name']}"
@@ -241,7 +241,7 @@ def generate_predominant_languages_graph(oss_entity):
     bar_chart.title = f"Predominant Languages in {oss_entity.metric_data['name']}"
 
     predominant_lang = oss_entity.metric_data['predominant_langs']
-    
+
     for lang, lines in predominant_lang.items():
         bar_chart.add(lang, lines)
 
@@ -254,7 +254,7 @@ def parse_libyear_list(dependency_list):
 
     Arguments:
         dependency_list: the list of lists that has the deps data
-    
+
     Returns:
         A list of dictionaries describing deps
     """
@@ -292,10 +292,10 @@ def generate_libyears_graph(oss_entity):
     if not raw_dep_list:
         return
 
-    #This is going to be kind of hacky since pygals doesn't have a 
+    #This is going to be kind of hacky since pygals doesn't have a
     #timeline object
     #TODO: Contribute upstream to add a timeline object to pygal
-    dateline = pygal.TimeDeltaLine(x_label_rotation=25)
+    dateline = pygal.TimeDeltaLine(x_label_rotation=25,legend_at_bottom=True)
 
     dateline.title = 'Dependency Libyears: Age of Dependency Version in Days'
 
@@ -311,6 +311,10 @@ def generate_libyears_graph(oss_entity):
 
         #move one line up so that we have no overlap in the timedeltas
         elevation += 1
-    
+
+        if elevation >= 40:
+            break
+
+    dateline.show_y_labels = False
     write_repo_chart_to_file(oss_entity, dateline, "libyear_timeline")
 

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -235,3 +235,51 @@ def generate_predominant_languages_graph(oss_entity):
         bar_chart.add(lang, lines)
 
     write_repo_chart_to_file(oss_entity, bar_chart, "predominant_langs")
+
+def parse_libyear_dates(dependency_list):
+    """
+    Parses the dependency list returned from the libyear metric into a list of python dictionaries
+    that have correctly parsed dates.
+
+    Arguments:
+        dependency_list: the list of lists that has the deps data
+    
+    Returns:
+        A list of dictionaries describing deps
+    """
+
+    to_return = []
+    for dep in dependency_list:
+
+
+        date = datetime.datetime.strptime(dep[3], '%Y-%m-%dT%H:%M:%S.%f')
+        to_return.append(
+            {
+                "repository": dep[0],
+                "dep_name": dep[1],
+                "libyear_value": dep[2],
+                "libyear_date_last_updated": date
+            }
+        )
+    
+    return to_return
+
+
+def generate_libyears_graph(oss_entity):
+    """
+    Generates a pygal graph to describe libyear metrics for the requested oss_entity
+
+    Arguments:
+        oss_entity: the OSSEntity to create a libyears graph for.
+    """
+
+    dep_list = oss_entity.metric_data['repo_dependency_libyear_list']
+    if not dep_list:
+        return
+    
+    line_chart = pygal.Line()
+
+    line_chart.title = 'Dependency Libyears'
+
+
+    line_chart.x_labels = map(str, range(2002, 2013))

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -20,8 +20,12 @@ def generate_all_graphs_for_repos(all_repos):
         generate_predominant_languages_graph(repo)
         try:
             generate_donut_graph_line_complexity_graph(repo)
-            generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_month", "New Contributors")
-            generate_time_xy_issue_graph(repo, "new_commit_contributors_by_day_over_last_six_months", "New Contributors")
+            generate_time_xy_issue_graph(
+                repo, "new_commit_contributors_by_day_over_last_month", "New Contributors"
+            )
+            generate_time_xy_issue_graph(
+                repo, "new_commit_contributors_by_day_over_last_six_months", "New Contributors"
+            )
         except KeyError as e:
             print(f"Could not find metrics to build graphs for repo {repo.name}")
             print(e)
@@ -306,7 +310,7 @@ def generate_libyears_graph(oss_entity):
     for dep in dep_list:
         dateline.add(dep["dep_name"], [
             (timedelta(), elevation),
-            (timedelta(days=(dep["libyear_value"] * 365)), elevation),
+            (timedelta(days=dep["libyear_value"] * 365), elevation),
         ])
 
         #move one line up so that we have no overlap in the timedeltas
@@ -317,4 +321,3 @@ def generate_libyears_graph(oss_entity):
 
     dateline.show_y_labels = False
     write_repo_chart_to_file(oss_entity, dateline, "libyear_timeline")
-

--- a/templates/org_report_template.md
+++ b/templates/org_report_template.md
@@ -111,5 +111,7 @@ date_stampLastWeek: {date_stamp}
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_new_issues_by_day_over_last_six_months.svg", title: "New Issues over Last 6 Months" %}}
     <!-- Top Committers Bar Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_top_committers.svg", title: "Top Committers" %}}
+    <!-- Top Committers Bar Graph -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_owner}_libyear_timeline.svg", title: "Top Committers" %}}
   </div>
 </div>

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -113,4 +113,6 @@ date_stampLastWeek: {date_stamp}
       {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
     <!-- Predominant Lanugages Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg", title: "Predominant Languages" %}}
+    <!-- Libyear Timeline Graph -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/libyear_timeline_{repo_name}_data.svg", title: "Dependency Libyears" %}}
 </div>


### PR DESCRIPTION
## Create Graph for Libyears Metric

## Problem

We have yet to create visualizations for all of our metrics, specifically the Libyears percentage. 

Libyears is a metric that is meant to give a general idea of how out of date dependencies in a given group or project are. It gives a measure of how many years out of date the current version of a given dependency is. 

For more information about libyears:

- https://libyear.com/
- https://chaoss.community/kb/metric-libyears/

## Solution

Implement a visualization of the libyears metric using a pygal [TimeDeltaLine](https://www.pygal.org/en/3.0.0/documentation/types/xy.html#timedelta). 

## Result

![Screenshot_20241009_143056](https://github.com/user-attachments/assets/6a1e2b84-b5fa-4c5e-980e-fa87e554614e)



Summary:

* Add a function to parse libyear dependency list taken from Augur
* Parse each list string and convert them into datetime objects
* Add a check to make sure dependency data is not empty
* Use TimeDeltaLine to create libyear graphs that show the timedelta for each dep
* Use the libyear score to calculate the age of the dep in days
* Set each dep on its own value for the y-axis to space out the timelines (elevation)

## Test Plan

I have tested locally.
