### PR TITLE
Add Missing Value Formatting Methods

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -6,6 +6,19 @@ from datetime import timedelta
 import re
 import pygal
 
+
+def percent_formatter(x):
+    """
+    Function to format percentage values.
+
+    Arguments:
+        x: Value to format into a percent
+    Returns:
+        A string containing the formatted version of x
+    """
+
+    return '{:0.2f}%'.format(x)
+
 def generate_all_graphs_for_repos(all_repos):
     """
     Function to generate and save all graphs for the input
@@ -174,8 +187,6 @@ def generate_solid_gauge_issue_graph(oss_entity):
 
     issues_gauge = pygal.SolidGauge(inner_radius=0.70, legend_at_bottom=True)
 
-    def percent_formatter(x):
-        return '{:0.2f}%'.format(x)
     issues_gauge.value_formatter = percent_formatter
 
     # Generate graph to measure percentage of issues that are open
@@ -379,6 +390,7 @@ def generate_dryness_percentage_graph(oss_entity):
     uloc_percent = (float(dryness_values['total_uloc']) / sloc) * 100
 
     pie_chart = pygal.Pie(half_pie=True, legend_at_bottom=True)
+    pie_chart.value_formatter = percent_formatter
     pie_chart.title = 'DRYness Percentage Graph'
 
     #print(dryness_values)

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -19,6 +19,30 @@ def percent_formatter(x):
 
     return '{:0.2f}%'.format(x)
 
+def timedelta_formatter(x):
+    """
+    Function to format percentage values.
+
+    Arguments:
+        x: Value to format into days
+    Returns:
+        A string containing the formatted version of x
+    """
+
+    return '{} days'.format(x.days)
+
+def ignore_formatter(x):
+    """
+    Function to ignore values in formatting
+
+    Arguments:
+        x: Value to ignore
+    Returns:
+        A string containing the formatted version of x
+    """
+
+    return ''
+
 def generate_all_graphs_for_repos(all_repos):
     """
     Function to generate and save all graphs for the input
@@ -317,7 +341,8 @@ def generate_libyears_graph(oss_entity):
     #timeline object
     #TODO: Contribute upstream to add a timeline object to pygal
     dateline = pygal.TimeDeltaLine(x_label_rotation=25,legend_at_bottom=True)
-
+    dateline.x_value_formatter = timedelta_formatter
+    dateline.value_formatter = ignore_formatter
     dateline.title = 'Dependency Libyears: Age of Dependency Version in Days'
 
     dep_list = parse_libyear_list(raw_dep_list)
@@ -348,7 +373,7 @@ def parse_cocomo_dryness_metrics(dryness_string):
 
     Arguments:
         dryness_string: the string containing the dryness table to parse
-    
+
     Returns:
         A dictionary with the unique lines of code and DRYness percentage
     """
@@ -376,7 +401,7 @@ def generate_dryness_percentage_graph(oss_entity):
     WETness = 1 - DRYness
 
     DRY = Don't repeat yourself
-    WET = Waste Everybody's time or Write Everything Twice 
+    WET = Waste Everybody's time or Write Everything Twice
     """
 
     dryness_values = parse_cocomo_dryness_metrics(
@@ -401,7 +426,7 @@ def generate_dryness_percentage_graph(oss_entity):
 
     #Will cause a value error if the dryness value is NaN which can happen.
     pie_chart.add(
-        'Source Lines of Code (SLOC) %', 
+        'Source Lines of Code (SLOC) %',
         #sloc = uloc / DRYness
         sloc_percent
     )


### PR DESCRIPTION
## Add Missing Value Formatting Methods

## Problem

Some graphs that are present in the dev branch could have values that are better formatted. For example the DRYness percentage graph has no percentage formatting associated with it.

## Solution

I have used new and existing format methods to add formatting to the libyear and dryness visualizations. 

## Result
New libyear graph:
![Screenshot_20241010_160547](https://github.com/user-attachments/assets/09e4550a-2df2-45a1-881c-0c252cf65cf4)


New DRYness graph:
![Screenshot_20241010_160230](https://github.com/user-attachments/assets/7ac80bdc-9b34-4668-b83b-b731e9789115)

Summary:

* Move percent_formatter up in scope to be used by other methods in the module
* Add a timedelta formatter to only show days 
* Add a formatter method to ignore the provided value entirely 
* Add percent formatter to DRYness method
* Add timedelta formatter to libyear graph's y-axis 
* Ignore the y-axis in the libyear graph

## Test Plan

I have tested locally
