### PR TITLE
Add cost estimates dk

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -19,6 +19,7 @@ def generate_all_graphs_for_repos(all_repos):
         generate_repo_sparklines(repo)
         generate_predominant_languages_graph(repo)
         generate_language_summary_pie_chart(repo)
+        generate_cost_estimates_bar_chart(repo)
         try:
             generate_donut_graph_line_complexity_graph(repo)
             generate_time_xy_issue_graph(
@@ -342,3 +343,31 @@ def generate_language_summary_pie_chart(oss_entity):
         pie_chart.add(entry['Name'], code_lines)
 
     write_repo_chart_to_file(oss_entity, pie_chart, "language_summary")
+
+
+def generate_cost_estimates_bar_chart(oss_entity):
+    """
+    This function generates a pygal bar chart for estimated costs with rounded values and a dollar sign.
+
+    Arguments:
+        oss_entity: the OSSEntity to create a graph for.
+    """
+
+    bar_chart = pygal.Bar()
+
+    metric_data = oss_entity.metric_data['cocomo']
+
+    estimatedCost_low = metric_data.get('estimatedCost_low', 0)
+    estimatedCost_high = metric_data.get('estimatedCost_high', 0)
+
+    bar_chart.value_formatter = lambda x: f'${x:,.2f}'
+
+    average_cost = (estimatedCost_low + estimatedCost_high) / 2
+
+    bar_chart.title = f'Estimated Project Costs in $ (Average Cost: ${average_cost:,.2f})'
+
+    bar_chart.add(f'Estimated Cost Low (${estimatedCost_low:,.2f})', estimatedCost_low)
+    bar_chart.add(f'Estimated Cost High (${estimatedCost_high:,.2f})', estimatedCost_high)
+
+    write_repo_chart_to_file(oss_entity, bar_chart, "estimated_project_costs")
+

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -315,20 +315,30 @@ def generate_dryness_percentage_graph(oss_entity):
 
     write_repo_chart_to_file(oss_entity, pie_chart, "DRYness")
 
+
 def generate_language_summary_pie_chart(oss_entity):
     """
-    This function generates a pygal for programming languages and total lines written in each language.
-
+    This function generates a pygal pie chart for programming languages and total lines written in each language.
+    The total LoC is displayed in the chart's title.
+    
     Arguments:
-        oss_entity: the OSSEntity to create a graph for.    
+        oss_entity: the OSSEntity to create a graph for.
     """
 
     pie_chart = pygal.Pie()
-    pie_chart.title = 'Language Summary'
 
-    language_summary = oss_entity.metric_data['cocomo']['languageSummary']
+    language_summary = oss_entity.metric_data.get('cocomo', {}).get('languageSummary')
+    if not language_summary:
+        raise ValueError("No valid 'languageSummary' found in the data.")
+
+    total_loc = sum(entry.get('Code', 0) for entry in language_summary)
+    
+    pie_chart.title = f'Language Summary (Total SLOC: {total_loc:,})'
+
+    pie_chart.value_formatter = lambda x: f'{x} SLOC'
 
     for entry in language_summary:
-        pie_chart.add(entry['Name'], entry['Code'])
+        code_lines = entry.get('Code', 0)
+        pie_chart.add(entry['Name'], code_lines)
 
     write_repo_chart_to_file(oss_entity, pie_chart, "language_summary")

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -117,4 +117,6 @@ date_stampLastWeek: {date_stamp}
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/DRYness_{repo_name}_data.svg", title: "DRYness Percentage Graph" %}}
      <!-- Language Summary Chart -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/language_summary_{repo_name}_data.svg", title: "Language Summary" %}}
+    <!-- Cost Estimate Chart -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/estimated_project_costs_{repo_name}_data.svg", title: "Estimated Costs" %}}
 </div>


### PR DESCRIPTION
#251 
## module-name: Add a cost estimate bar graph

## Problem
Need a front-end visualization of estimated costs of developing a project.

## Solution
Create a bar graph using Pygal to implement the missing field for cost estimates.

## Result
A bar chart depicting cost estimates populates in the browser.

## Test Plan
Manually test in the browser.

![Screenshot 2024-10-10 at 6 30 41 PM](https://github.com/user-attachments/assets/732f6d72-7b93-4873-a63e-1f73d176c5ee)
