### PR TITLE
Consolidated Language Graphs V2

### DIFF
--- a/app/site/_includes/graph-toggle.liquid
+++ b/app/site/_includes/graph-toggle.liquid
@@ -34,7 +34,7 @@
             {% endif %}
             {% assign graphPath = graph | strip %}
             {% assign distPath = baseurl | append: "/assets/img/graphs" | append: graphPath %}
-            {% assign fileExtension = graphPathath | split: '.' | last %}
+            {% assign fileExtension = graphPath | split: '.' | last %}
             <figure>
             {% if fileExtension == 'svg' %}
                 <embed type="image/svg+xml" src="{{ distPath }}" />

--- a/app/site/_includes/graph-toggle.liquid
+++ b/app/site/_includes/graph-toggle.liquid
@@ -34,7 +34,7 @@
             {% endif %}
             {% assign graphPath = graph | strip %}
             {% assign distPath = baseurl | append: "/assets/img/graphs" | append: graphPath %}
-            {% assign fileExtension = path | split: '.' | last %}
+            {% assign fileExtension = graphPathath | split: '.' | last %}
             <figure>
             {% if fileExtension == 'svg' %}
                 <embed type="image/svg+xml" src="{{ distPath }}" />

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -111,14 +111,14 @@ date_stampLastWeek: {date_stamp}
       {{% assign optionsArray = '1 Month, 6 Month' | split: ',' %}}
       {{% assign graphsArray = '/{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_month_{repo_name}_data.svg, /{repo_owner}/{repo_name}/new_commit_contributors_by_day_over_last_six_months_{repo_name}_data.svg' | split: ',' %}}
       {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
-    <!-- Predominant Languages Graph -->
-    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg", title: "Predominant Languages" %}}
+    <!-- Languages Graphs - Summary + Predominant -->
+    {{% assign optionsArray = 'Summary, Predominant' | split: ',' %}}
+    {{% assign graphsArray = "/{repo_owner}/{repo_name}/language_summary_{repo_name}_data.svg, /{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg" | split: ',' %}}
+    {{% render "graph-toggle" baseurl: site.baseurl, name:"language-information" options: optionsArray, graphs: graphsArray, title: "Language Information" %}}
     <!-- Libyear Timeline Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/libyear_timeline_{repo_name}_data.svg", title: "Dependency Libyears" %}}
     <!-- DRYness Percentages Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/DRYness_{repo_name}_data.svg", title: "DRYness Percentage Graph" %}}
-     <!-- Language Summary Chart -->
-    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/language_summary_{repo_name}_data.svg", title: "Language Summary" %}}
     <!-- Cost Estimate Chart -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/estimated_project_costs_{repo_name}_data.svg", title: "Estimated Costs" %}}
 </div>


### PR DESCRIPTION
## Consolidated Language Graphs

## Problem

Predominant Language and Language Summary graphs showed very similar information. 

## Solution

Consolidated the two graphs into one using graph-toggle.

## Result

User can switch between both graphs instead of having both presented at once.
![chrome-capture-2024-10-15](https://github.com/user-attachments/assets/2fcf1bc3-6770-4d6d-908b-7eda83a37bb0)

Some important notes regarding the summary line:

- Had a branch that got messed up so i closed it
- This is updated and correct branch

## Test Plan

Tested locally.
