### PR TITLE
Add Logic to Handle if Key Encounters GitHub API Rate Limit

### DIFF
--- a/scripts/metricsLib/constants.py
+++ b/scripts/metricsLib/constants.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from enum import Enum
 
 TIMEOUT_IN_SECONDS = 120
+REQUEST_RETRIES = 5
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 # Folder Names to send over our projects tracked data
 PATH_TO_METRICS_DATA = (Path(__file__).parent /

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -4,6 +4,7 @@ Module to define classes of metrics that gather data given parameters
 import json
 from json.decoder import JSONDecodeError
 import datetime
+from time import sleep, mktime, gmtime, time, localtime
 from functools import reduce
 import operator
 import requests
@@ -75,25 +76,49 @@ class BaseMetric:
             endpoint_to_hit = self.url.format(**params)
             request_params = None
 
-        if self.headers:
-            _args_ = (self.method, endpoint_to_hit)
-            _kwargs_ = {
-                "params": request_params,
-                "headers": self.headers,
-                "timeout": TIMEOUT_IN_SECONDS
-            }
-            response = requests.request(*_args_, **_kwargs_)
-        else:
-            response = requests.request(
-                self.method, endpoint_to_hit, params=request_params, timeout=TIMEOUT_IN_SECONDS)
+        attempts = 0
 
-        try:
-            if response.status_code == 200:
-                response_json = json.loads(response.text)
+        while attempts < 10:
+            if self.headers:
+                _args_ = (self.method, endpoint_to_hit)
+                _kwargs_ = {
+                    "params": request_params,
+                    "headers": self.headers,
+                    "timeout": TIMEOUT_IN_SECONDS
+                }
+                response = requests.request(*_args_, **_kwargs_)
             else:
-                raise ConnectionError(f"Non valid status code {response.status_code}!")
-        except JSONDecodeError:
-            response_json = {}
+                response = requests.request(
+                    self.method, endpoint_to_hit, params=request_params, timeout=TIMEOUT_IN_SECONDS)
+
+            try:
+                if response.status_code == 200:
+                    response_json = json.loads(response.text)
+                    break
+
+                #check for rate limit response
+                if response.status_code in (403,429):
+                    #rate limit was triggered.
+                    wait_until = int(response.headers.get("x-ratelimit-reset"))
+                    wait_in_seconds = int(
+                        mktime(gmtime(wait_until)) -
+                        mktime(gmtime(time()))
+                    )
+                    wait_until_time = localtime(wait_until)
+
+                    print(f"Ran into rate limit sleeping for {self.name}!")
+                    print(
+                        f"sleeping until {wait_until_time.tm_hour}:{wait_until_time.tm_min} ({wait_in_seconds} seconds)"
+                    )
+                    sleep(wait_in_seconds)
+
+                    response_json = {}
+                    attempts += 1
+                else:
+                    raise ConnectionError(f"Non valid status code {response.status_code}!")
+            except JSONDecodeError:
+                response_json = {}
+                attempts += 1
 
         return response_json
 

--- a/scripts/metricsLib/metrics_data_structures.py
+++ b/scripts/metricsLib/metrics_data_structures.py
@@ -95,9 +95,7 @@ class BaseMetric:
                 if response.status_code == 200:
                     response_json = json.loads(response.text)
                     break
-
-                #check for rate limit response
-                if response.status_code in (403,429):
+                elif response.status_code in (403,429):
                     #rate limit was triggered.
                     wait_until = int(response.headers.get("x-ratelimit-reset"))
                     wait_in_seconds = int(


### PR DESCRIPTION
## Add Logic to Handle if Key Encounters GitHub API Rate Limit

## Problem

The script doesn't handle the situation where it encounters a GitHub rate limit. 

## Solution

Check the api response object to see if a rate limit status was encountered. If it was then sleep for the amount of time given by the GitHub response header `x-ratelimit-reset`. 

More information on the GitHub rate limit can be found here: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28

## Result

Summary:

* Add loop to retry when issues are encountered
* Check response code for rate limit ( 403 and 429 )
* Extract `x-ratelimit-reset` from response header if rate limit triggered, this is a timestamp for when the key will be good again. We convert the timestamp into a duration in seconds and then sleep for that many seconds
* Get local time for when the key will be good again and print to stdout
* Raise ConnectionError if rate limit still happens after 5 tries


## Test Plan

I have tested the script locally 