### PR TITLE
Added Frontend and Backend for Average Issue Resolution Time Graph

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -5,6 +5,7 @@ import datetime
 from datetime import timedelta
 import re
 import pygal
+import random
 
 
 def percent_formatter(x):
@@ -58,6 +59,7 @@ def generate_all_graphs_for_repos(all_repos):
         generate_predominant_languages_graph(repo)
         generate_language_summary_pie_chart(repo)
         generate_cost_estimates_bar_chart(repo)
+        generate_average_issue_resolution_graph(repo)
         try:
             generate_donut_graph_line_complexity_graph(repo)
             generate_time_xy_issue_graph(
@@ -491,3 +493,32 @@ def generate_cost_estimates_bar_chart(oss_entity):
 
     write_repo_chart_to_file(oss_entity, bar_chart, "estimated_project_costs")
 
+def generate_average_issue_resolution_graph(oss_entity):
+    """
+    This function generates a pygal gauge chart for average issue resolution time.
+
+    Arguments:
+        oss_entity: An object containing the metric data.
+    """
+    gauge_graph = pygal.Gauge(legend_at_bottom=True)
+    
+    metric_data = oss_entity.metric_data.get('average_issue_resolution_time')
+    if not metric_data or not metric_data[0]:
+        print("No data available for average issue resolution time")
+        return
+
+    data = metric_data[0]
+    repo_name = data[0]
+    average_time_str = data[1]
+
+    days_str = average_time_str.split(' days ')
+    days = int(days_str[0])
+
+    random_numbers = [10,20,30,40,50,60]
+
+    gauge_graph.range = [0, (days + random.choice(random_numbers))]
+
+    gauge_graph.title = f"Average Issue Resolution Time for {repo_name} \n Average Time: {round(days)} days"
+    gauge_graph.add("Days", round(days))
+
+    write_repo_chart_to_file(oss_entity, gauge_graph, "average_issue_resolution_time")

--- a/scripts/metricsLib/metrics_definitions.py
+++ b/scripts/metricsLib/metrics_definitions.py
@@ -184,7 +184,6 @@ RESOURCE_METRICS.append(ResourceMetric("firstResponseForClosedPR", sixMonthsPara
                                 AUGUR_HOST + "/pull_request_reports/PR_time_to_first_response/" +
                                 "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))
 
-
 ORG_GITHUB_GRAPHQL_QUERY = """
 query ($org_login: String!) {
   organization(login: $org_login) {
@@ -252,3 +251,12 @@ ADVANCED_METRICS.append(ListMetric(
   }
   )
 )
+
+SIMPLE_METRICS.append(ListMetric("averageIssueResolutionTime", sixMonthsParams, AUGUR_HOST + "/repos/" + "{repo_id}" + "/average-issue-resolution-time", {"average_issue_resolution_time": ["repo_name", "avg_issue_resolution_time"]}))
+
+# Metric for Average Commit Counts per PR
+# TODO: - Currently not working because of something wrong on Augur's end. Develop a solution here (hacky) or fix upstream.
+
+# RESOURCE_METRICS.append(ResourceMetric("averageCommitsPerPR", sixMonthsParams,
+#                                 AUGUR_HOST + "/pull_request_reports/average_commits_per_PR/" +
+#                                 "?repo_id={repo_id}&start_date={begin_month}&end_date={end_date}"))

--- a/templates/repo_report_template.md
+++ b/templates/repo_report_template.md
@@ -113,6 +113,8 @@ date_stampLastWeek: {date_stamp}
       {{% render "graph-toggle", baseurl: site.baseurl, name: "new-contributors" options: optionsArray, graphs: graphsArray, title: "Number of Contributors Joining per Interval" %}}
     <!-- Predominant Languages Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/predominant_langs_{repo_name}_data.svg", title: "Predominant Languages" %}}
+    <!-- Average Issue Resolution Time -->
+    {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/average_issue_resolution_time_{repo_name}_data.svg", title: "Average Issue Resolution Time" %}}
     <!-- Libyear Timeline Graph -->
     {{% render "graph-section" baseurl: site.baseurl, path: "/{repo_owner}/{repo_name}/libyear_timeline_{repo_name}_data.svg", title: "Dependency Libyears" %}}
     <!-- DRYness Percentages Graph -->


### PR DESCRIPTION
## Added Frontend and Backend for Average Issue Resolution Time Graph

## Problem

Average Issue Resolution Time is a metric available on Augur but wasn't accessible within our metrics.

## Solution

Implemented frontend and backend API call to display and receive this data.

## Result

Average Issue Resolution Time is now available in metrics
<img width="815" alt="Screen Shot 2024-10-17 at 1 54 48 PM" src="https://github.com/user-attachments/assets/f0d9ec3e-e539-4c1f-be67-78bb52577f88">

Some important notes regarding the summary line:

* Only a select few repos have this graph available since every repo doesn't have issues.

## Test Plan

Tested locally. 
