### PR TITLE
Patch Libyear Graph to Reverse Order

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -315,17 +315,18 @@ def parse_libyear_list(dependency_list):
     for dep in dependency_list:
 
         #print(dep)
-        date = datetime.datetime.strptime(dep[-1], '%Y-%m-%dT%H:%M:%S.%f')
-        to_return.append(
-            {
-                "dep_name": dep[-3],
-                "libyear_value": dep[-2],
-                "libyear_date_last_updated": date
-            }
-        )
+        if dep[-2] >= 0:
+            date = datetime.datetime.strptime(dep[-1], '%Y-%m-%dT%H:%M:%S.%f')
+            to_return.append(
+                {
+                    "dep_name": dep[-3],
+                    "libyear_value": dep[-2],
+                    "libyear_date_last_updated": date
+                }
+            )
 
     #return list sorted by date
-    return sorted(to_return, key=lambda d : d["libyear_value"])
+    return sorted(to_return, key=lambda d : d["libyear_value"],reverse=True)
 
 
 def generate_libyears_graph(oss_entity):


### PR DESCRIPTION
## Patch Libyear Graph to Reverse Order

## Problem

The Libyear Graph shows libyear data from least out of date to most out of date. We want it to prioritize showing the most out of date libraries on the chart instead of the least out of date ones. 

## Solution

I have reversed the sorting order of the libyear data list. 

## Result

Summary:

* Ignore all negative libyear values
* Set reverse=true for `sorted` method

## Test Plan

The first value in the data list is the bottom element and will always be given priority to display first.
Before:
![image](https://github.com/user-attachments/assets/d4d67394-20a9-4046-abc8-2146b3e922c9)
After:
![image](https://github.com/user-attachments/assets/c15a3d6d-b262-4827-b121-2b40c60aa009)

