### PR TITLE
Add Missing Public DSACMS Repositories

### DIFF
--- a/scripts/_metadata/projects_tracked.json
+++ b/scripts/_metadata/projects_tracked.json
@@ -16,7 +16,6 @@
             "https://github.com/DSACMS/dedupliFHIR",
             "https://github.com/DSACMS/opportunities",
             "https://github.com/DSACMS/drive2gource",
-            "https://github.com/DSACMS/cms-gource",
             "https://github.com/DSACMS/iv-cbv-payroll",
             "https://github.com/DSACMS/repodive-tools",
             "https://github.com/DSACMS/ospo-guide",

--- a/scripts/_metadata/projects_tracked.json
+++ b/scripts/_metadata/projects_tracked.json
@@ -16,6 +16,15 @@
             "https://github.com/DSACMS/dedupliFHIR",
             "https://github.com/DSACMS/opportunities",
             "https://github.com/DSACMS/drive2gource",
+            "https://github.com/DSACMS/cms-gource",
+            "https://github.com/DSACMS/iv-cbv-payroll",
+            "https://github.com/DSACMS/repodive-tools",
+            "https://github.com/DSACMS/ospo-guide",
+            "https://github.com/DSACMS/oss-community-runbook",
+            "https://github.com/DSACMS/income-reporting-playbook",
+            "https://github.com/DSACMS/reverse-scorecard-generation",
+            "https://github.com/DSACMS/mural-ollama",
+            "https://github.com/DSACMS/iv-verify",
             "https://github.com/DSACMS/cms-gource"
         ],   
         "Enterprise-CMCS": [ 


### PR DESCRIPTION
## Add Missing Public DSACMS Repositories

## Problem

Currently, we are only tracking a small subset of the repositories in the DSACMS GitHub org. 

## Solution

Add more public repositories from DSACMS GitHub org.

