### PR TITLE
Use Better Augur Utility Endpoint

### DIFF
--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -221,7 +221,10 @@ class Repository(OSSEntity):
             self.augur_util_endpoint, timeout=TIMEOUT_IN_SECONDS)
         response_json = json.loads(response.text)
 
+        print("--------")
+        print(endpoint)
         print(response_json)
+        print("--------")
         repo_val = response_json[0]
 
         # print(f"!!!{repo_val}")

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -214,7 +214,7 @@ class Repository(OSSEntity):
         #    endpoint = f"{AUGUR_HOST}/repos"
         #else:
         #    endpoint = f"{AUGUR_HOST}/repo-groups/{owner_id}/repos"
-        endpoint = f"{AUGUR_HOST}owner/{owner.lower()}/repo/{repo_name}"
+        endpoint = f"{AUGUR_HOST}owner/{owner.lower()}/repo/{repo_name.lower()}"
         super().__init__(repo_name, endpoint)
 
         response = requests.get(
@@ -225,19 +225,23 @@ class Repository(OSSEntity):
         print(endpoint)
         print(response_json)
         print("--------")
-        repo_val = response_json[0]
+
+        try:
+            repo_val = response_json[0]
+        except IndexError:
+            repo_val = {}
 
         # print(f"!!!{repo_val}")
         # for x in response_json:
         #    print(f"|{x['repo_name'].lower()}=={repo_name.lower()}|")
         # print(repo_val)
-        self.repo_id = repo_val['repo_id']
+        self.repo_id = repo_val.get('repo_id')
 
         #print(f"repo id: {self.repo_id}")
         if owner_id is not None:
             self.repo_group_id = owner_id
         else:
-            self.repo_group_id = repo_val['repo_group_id']
+            self.repo_group_id = repo_val.get('repo_group_id')
 
 
         # print(f"BEGIN: {today.strftime('%Y/%m/%d')}")

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -214,7 +214,7 @@ class Repository(OSSEntity):
         #    endpoint = f"{AUGUR_HOST}/repos"
         #else:
         #    endpoint = f"{AUGUR_HOST}/repo-groups/{owner_id}/repos"
-        endpoint = f"{AUGUR_HOST}/owner/{owner}/repo/{repo_name}"
+        endpoint = f"{AUGUR_HOST}owner/{owner.lower()}/repo/{repo_name}"
         super().__init__(repo_name, endpoint)
 
         response = requests.get(

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -210,29 +210,19 @@ class Repository(OSSEntity):
         #print(f"owner id: {owner_id}")
         #print(repo_git_url)
 
-        if owner_id is None:
-            endpoint = f"{AUGUR_HOST}/repos"
-        else:
-            endpoint = f"{AUGUR_HOST}/repo-groups/{owner_id}/repos"
+        #if owner_id is None:
+        #    endpoint = f"{AUGUR_HOST}/repos"
+        #else:
+        #    endpoint = f"{AUGUR_HOST}/repo-groups/{owner_id}/repos"
+        endpoint = f"{AUGUR_HOST}/owner/{owner}/repo/{repo_name}"
         super().__init__(repo_name, endpoint)
 
         response = requests.get(
             self.augur_util_endpoint, timeout=TIMEOUT_IN_SECONDS)
         response_json = json.loads(response.text)
 
-        #(response_json)
-        try:
-            repo_name.lower()
-
-
-            repo_val = next(
-                x for x in
-                response_json if x['repo_name'] and x['repo_name'].lower() == repo_name.lower())
-        except StopIteration:
-            print(f"Could not find repo {repo_git_url} in group {owner_id}")
-            repo_val = {
-                'repo_id': None
-            }
+        print(response_json)
+        repo_val = response_json[0]
 
         # print(f"!!!{repo_val}")
         # for x in response_json:

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -221,11 +221,6 @@ class Repository(OSSEntity):
             self.augur_util_endpoint, timeout=TIMEOUT_IN_SECONDS)
         response_json = json.loads(response.text)
 
-        print("--------")
-        print(endpoint)
-        print(response_json)
-        print("--------")
-
         try:
             repo_val = response_json[0]
         except IndexError:


### PR DESCRIPTION
## Use Better Augur Utility Endpoint

## Problem

We are currently using an inefficient augur api endpoint when we could be using a better one.

## Solution

Instead of querying the repo_group_id from augur and iterating over it just query the repository directly via name and owner. 


## Test Plan

I have [tested this branch](https://github.com/IsaacMilarky/metrics/actions/runs/11711268212) in my fork of metrics. 
