### PR TITLE
Patch Org Libyear Graph to Include Project Names

### DIFF
--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -371,7 +371,7 @@ def generate_libyears_graph(oss_entity):
     elevation = 0
     for dep in dep_list:
 
-        label = f"{dep["dep_name"]}/{dep["repo_name"]}"
+        label = f"{dep['dep_name']}/{dep['repo_name']}"
         
         dateline.add(label, [
             (timedelta(), elevation),

--- a/scripts/gen_graphs.py
+++ b/scripts/gen_graphs.py
@@ -317,12 +317,20 @@ def parse_libyear_list(dependency_list):
         #print(dep)
         if dep[-2] >= 0:
             date = datetime.datetime.strptime(dep[-1], '%Y-%m-%dT%H:%M:%S.%f')
+
+            dep_dict = {
+                "dep_name": dep[-3],
+                "libyear_value": dep[-2],
+                "libyear_date_last_updated": date
+            }
+
+            if len(dep) > 3:
+                dep_dict['repo_name'] = dep[0]
+            else:
+                dep_dict['repo_name'] = ''
+
             to_return.append(
-                {
-                    "dep_name": dep[-3],
-                    "libyear_value": dep[-2],
-                    "libyear_date_last_updated": date
-                }
+                dep_dict
             )
 
     #return list sorted by date
@@ -362,7 +370,10 @@ def generate_libyears_graph(oss_entity):
     #We are going to treat the y-axis as having one dep per level in the graph
     elevation = 0
     for dep in dep_list:
-        dateline.add(dep["dep_name"], [
+
+        label = f"{dep["dep_name"]}/{dep["repo_name"]}"
+        
+        dateline.add(label, [
             (timedelta(), elevation),
             (timedelta(days=dep["libyear_value"] * 365), elevation),
         ])

--- a/scripts/metricsLib/oss_metric_entities.py
+++ b/scripts/metricsLib/oss_metric_entities.py
@@ -214,7 +214,7 @@ class Repository(OSSEntity):
         #    endpoint = f"{AUGUR_HOST}/repos"
         #else:
         #    endpoint = f"{AUGUR_HOST}/repo-groups/{owner_id}/repos"
-        endpoint = f"{AUGUR_HOST}owner/{owner.lower()}/repo/{repo_name.lower()}"
+        endpoint = f"{AUGUR_HOST}/owner/{owner.lower()}/repo/{repo_name.lower()}"
         super().__init__(repo_name, endpoint)
 
         response = requests.get(
@@ -222,8 +222,10 @@ class Repository(OSSEntity):
         response_json = json.loads(response.text)
 
         try:
+            print(endpoint)
+            print(response_json)
             repo_val = response_json[0]
-        except IndexError:
+        except (IndexError,KeyError):
             repo_val = {}
 
         # print(f"!!!{repo_val}")


### PR DESCRIPTION
## Patch Org Libyear Graph to Include Project Names

## Problem
Currently the Org-level Libyear graph doesn't include the project name that the dependency belongs to.
Also, there is a syntax error with some of the api calls. 

## Solution

Add the project name to the org level graph. 

## Result
![DSACMS_libyear_timeline](https://github.com/user-attachments/assets/a3911e3a-c48e-4422-951a-16909fdcaec1)



Summary:

* Fix Augur query endpoint
* Parse project name if there are more than 3 entries in the dep info
* Change label to have project name in the format of `{dep_name}/{project_name}`

## Test Plan

I will test locally and in my fork
