### PR TITLE
Fix Metrics Title

### DIFF
--- a/app/site/_includes/nav.liquid
+++ b/app/site/_includes/nav.liquid
@@ -4,12 +4,11 @@
     <div class="usa-nav-bar">
       <div class="title">
         <img src="{{ "/assets/img/cms-logo.jpg" | url }}" class="logo" alt="CMS Logo">
-        <h1>Metrics Website</h1>
-      </div>
-      <div class="usa-logo">
-        <em class="usa-logo__text">
-          <a href="{{ "/" | url}}" title="{{site.title}}">{{ site.title }}</a>
-        </em>
+        <div class="usa-logo">
+          <em class="usa-logo__text">
+            <a href="{{ "/" | url}}" title="{{site.title}}">Open Source Respository Metrics Website</a>
+          </em>
+        </div>
       </div>
     </div>
     <nav aria-label="Primary navigation" class="usa-nav nav-styling">

--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -52,9 +52,9 @@ h1 {
   margin-right: 10px;
 }
 
-.usa-logo {
-  font-size: 1.5em;
-  margin: 1% 0 1% 0;
+.usa-logo a {
+  color: #043884;
+  font-size: 1.1em;
 }
 
 .usa-nav__primary-item {
@@ -692,13 +692,9 @@ iframe:focus, [href]:focus, [tabindex]:focus, [contentEditable=true]:focus {
 }
 
 @media screen and (min-width: 768px) {
-  h1 {
-    font-size: 1.9em;
-    margin: 3% 2% 0 2%;
-  }
-
   .logo {
-    width: 120px;
+    height: 50px;
+    width: auto;
   }
 
   .dashboard-container {
@@ -745,5 +741,7 @@ iframe:focus, [href]:focus, [tabindex]:focus, [contentEditable=true]:focus {
 }
 
 @media screen and (min-width: 1024px) {
-  
+  .usa-logo a{
+    font-size: 1.5em;
+  }
 }


### PR DESCRIPTION
## module-name: Fix Main Title
## Problem
The title of the Metrics website is not responsive, does not link to main page, does not reflect the metrics website accurately.

## Solution
- Title changed from "Metrics Website" to "Open Source Repository Metrics Website." 
- Sized for responsiveness
- H2 tag "CMS.gov Open Source Repository Metrics" removed.
- Margins changed for better alignment.

## Result
Title tag now functions as desired.

## Test Plan
Checked locally and in production.
