### PR TITLE
Refactor modal 

### DIFF
--- a/app/site/_includes/modal-content.liquid
+++ b/app/site/_includes/modal-content.liquid
@@ -29,7 +29,7 @@
         data-close-modal
       >
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-          <use href="/assets/img/sprite.svg#close"></use>
+          <use href="{{ site.baseurl }}/assets/img/sprite.svg#close"></use>
         </svg>
       </button>
     </div>

--- a/app/src/js/modal.js
+++ b/app/src/js/modal.js
@@ -7,15 +7,24 @@ export function operateModal() {
         if(modal) {
             modal.classList.add("usa-modal--active");
             modal.setAttribute("aria-hidden", "false");
-            console.log("Modal is open")
+
+            let overlay = document.querySelector(".usa-modal-overlay");
+            if(!overlay) {
+                overlay = document.createElement("div");
+                overlay.className = "usa-modal-overlay";
+                overlay.setAttribute("data-close-modal", "");
+                document.body.appendChild(overlay);
+            }
         }
     };
 
     const closeModal = (modal) => {
+        const overlay = document.querySelector(".usa-modal-overlay");
+
         if(modal) {
             modal.classList.remove("usa-modal--active");
             modal.setAttribute("aria-hidden", "true");
-            console.log("modal is closed")
+            document.body.removeChild(overlay)
         }
     };
 


### PR DESCRIPTION
## module-name: Refactor modal

## Problem
The modal component does not have an overlay to darken the background on active.

## Solution
Create an overlay component to ensure easy user readability.

## Result
When the modal is activated the background darkens and all assets show as expected.

Some important notes regarding the summary line:
- `modal.js` refactored to add a `usa-modal-overlay` element on active
- `modal-content.liquid` refactored to show close icon for modal

## Test Plan
Test in local browser and in prod
