### PR TITLE
Fix-stat-spacing

### DIFF
--- a/app/site/_layouts/org-report.liquid
+++ b/app/site/_layouts/org-report.liquid
@@ -23,7 +23,7 @@ layout: base
         <div class="github-information org-info">
           <div class="stat-container" id="projects">
             <div class="projects-heading">
-              <h4 class=repo-stats>
+              <h4 class="repo-stats">
                 <span>
                   <svg
                     class="usa-icon"
@@ -40,7 +40,7 @@ layout: base
           </div>
           <div class="stat-container" id="followers">
             <div class="followers-heading">
-              <h4 class=repo-stats>
+              <h4 class="repo-stats">
                 <span>
                   <svg
                     class="usa-icon"

--- a/app/site/_layouts/org-report.liquid
+++ b/app/site/_layouts/org-report.liquid
@@ -16,52 +16,47 @@ layout: base
       >
     </h1>
   </div>
-
   <div class="report_container">
     {% if organization %}
       <h2>Organization Stats</h2>
-
       <div class="org-github-info">
-      <div class="github-information org-info">
-        <div class="stat-container" id="projects">
-          <div class="projects-heading">
-            <h4 class=repo-stats>
-              <span>
-                <svg
-                  class="usa-icon"
-                  aria-labelledby="projects-count"
-                  role="img"
-                >
-                  {% lucide "folder-git-2" %}
-                </svg>
-              </span>
-              Repositories
-            </h4>
+        <div class="github-information org-info">
+          <div class="stat-container" id="projects">
+            <div class="projects-heading">
+              <h4 class=repo-stats>
+                <span>
+                  <svg
+                    class="usa-icon"
+                    aria-labelledby="projects-count"
+                    role="img"
+                  >
+                    {% lucide "folder-git-2" %}
+                  </svg>
+                </span>
+                Repositories
+              </h4>
+            </div>
+            <p>{{ organization.repo_count }}</p>
           </div>
-          <p>{{ organization.repo_count }}</p>
-        </div>
-        <div class="stat-container" id="followers">
-          <div class="followers-heading">
-            <h4 class=repo-stats>
-              <span>
-                <svg
-                  class="usa-icon"
-                  aria-labelledby="followers-count"
-                  role="img"
-                >
-                  {% lucide "users-2" %}
-                </svg>
-              </span>
-              Followers
-            </h4>
+          <div class="stat-container" id="followers">
+            <div class="followers-heading">
+              <h4 class=repo-stats>
+                <span>
+                  <svg
+                    class="usa-icon"
+                    aria-labelledby="followers-count"
+                    role="img"
+                  >
+                    {% lucide "users-2" %}
+                  </svg>
+                </span>
+                Followers
+              </h4>
+            </div>
+            <p>{{ organization.followers_count }}</p>
           </div>
-          <p>{{ organization.followers_count }}</p>
         </div>
       </div>
-      </div>
-
-
-
     {% else %}
       <p>Error Occurred: Object Not Found</p>
     {% endif %}

--- a/app/site/_layouts/org-report.liquid
+++ b/app/site/_layouts/org-report.liquid
@@ -20,7 +20,9 @@ layout: base
   <div class="report_container">
     {% if organization %}
       <h2>Organization Stats</h2>
-      <div class="github-information">
+
+      <div class="org-github-info">
+      <div class="github-information org-info">
         <div class="stat-container" id="projects">
           <div class="projects-heading">
             <h4 class=repo-stats>
@@ -56,6 +58,10 @@ layout: base
           <p>{{ organization.followers_count }}</p>
         </div>
       </div>
+      </div>
+
+
+
     {% else %}
       <p>Error Occurred: Object Not Found</p>
     {% endif %}

--- a/app/site/_layouts/repo-report.liquid
+++ b/app/site/_layouts/repo-report.liquid
@@ -170,7 +170,24 @@ layout: base
           </div>
           <p>{{ project.pull_requests_count }}</p>
         </div>
-        <div class="stat-container" id="project-age" onclick="toggleDateAge(this)" style="cursor: pointer;">
+        <div class="stat-container" id="project-created">
+          <div class="project-age-heading">
+            <h4>
+              <span>
+                <svg
+                  class="usa-icon"
+                  aria-labelledby="project-created"
+                  role="img"
+                >
+                  {% lucide "calendar" %}
+                </svg>
+              </span>
+              Project Creation Date
+            </h4>
+          </div>
+          <p>{{ project.created_at | date: '%B %d, %Y' }}</p>
+        </div>
+        <div class="stat-container" id="project-age">
           <div class="project-age-heading">
             <h4>
               <span>
@@ -182,26 +199,20 @@ layout: base
                   {% lucide "calendar" %}
                 </svg>
               </span>
-              <span class="date">Project Creation Date</span>
-              <span class="age" style="display: none;">Age of Project</span>
+              Age of Project
             </h4>
           </div>
-          <p style="text-decoration: underline;">
-            <span class="date">
-              {{ project.created_at | date: '%B %d, %Y' }}
-            </span>
-            <span class="age" style="display: none;">
-              {% comment %} takes project created + todays date and turns it into seconds {% endcomment %}
-              {% assign created_date = project.created_at | date: '%s' | plus: 0 %}
-              {% assign current_date = 'now' | date: '%s' | plus: 0 %}
+          <p>
+            {% comment %} takes project created + todays date and turns it into seconds {% endcomment %}
+            {% assign created_date = project.created_at | date: '%s' | plus: 0 %}
+            {% assign current_date = 'now' | date: '%s' | plus: 0 %}
 
-              {% assign age_seconds = current_date | minus: created_date %}
+            {% assign age_seconds = current_date | minus: created_date %}
 
-              {% comment %} divide by how many seconds are in a day to convert back into days {% endcomment %}
-              {% assign age_days = age_seconds | divided_by: 86400.0 | round %}
+            {% comment %} divide by how many seconds are in a day to convert back into days {% endcomment %}
+            {% assign age_days = age_seconds | divided_by: 86400.0 | round %}
 
-              {{ age_days }} day{% if age_days != 1 %}s{% endif %}
-            </span>
+            {{ age_days }} day{% if age_days != 1 %}s{% endif %}
           </p>
         </div>
       </div>

--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -480,6 +480,11 @@ a.usa-link:visited {
   width: 95%;
 }
 
+/* .org-github-info {
+  display: flex;
+  justify-content: center;
+} */
+
 .github-information {
   display: flex;
   justify-content: space-around;
@@ -524,8 +529,6 @@ a.usa-link:visited {
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* flex-wrap: wrap; */
-  /* gap: 1rem; */
   justify-content: center;
 }
 
@@ -706,7 +709,11 @@ iframe:focus, [href]:focus, [tabindex]:focus, [contentEditable=true]:focus {
 
   .github-information {
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: center;
+  }
+
+  .org-info {
+    justify-content: space-evenly;
   }
 
   .stat-container {
@@ -756,6 +763,15 @@ iframe:focus, [href]:focus, [tabindex]:focus, [contentEditable=true]:focus {
 
   .home-icon-container {
     height: 90px;
+  }
+
+  .org-github-info {
+    display: flex;
+    justify-content: center;
+  }
+  
+  .org-info {
+    width: 50%;
   }
 }
 


### PR DESCRIPTION
## module-name: Fix spacing on organization and project stats

## Problem
- The organization are spaced to far apart on desktop and do not stack correctly on mobile devices.  
- The project statistics are spaced to close together on desktop and do not stack correctly on mobile devices.
- The toggle between `Project Creation Date` and `Age of Project` is not intuitive.

## Solution
- Org stats and project stats are sized according to screen size.
- Toggle removed from `Project Creation Date` and `Age of Project`

## Result
- Statistics now dynamically size. 

## Some important notes regarding the summary line:
- Add `div` element to size organization statistics
- Refactor `org-report.liquid` to remove toggle

## Test Plan
Test in browser and in prod.
