### PR TITLE
Filter refactor

### DIFF
--- a/app/site/projects.liquid
+++ b/app/site/projects.liquid
@@ -226,10 +226,10 @@ layout: base
           {% if currentPage < totalPages | minus: 1 %}
             <li class="usa-pagination__item usa-pagination__arrow">
               <a href="/projects/page/{{ currentPage | plus: 1 }}/" class="usa-pagination__link usa-pagination__next-page" aria-label="Next page">
-                <span class="usa-pagination__link-text">Next </span>
                 <svg class="usa-icon" aria-hidden="true" role="img">
                   <use xlink:href="/assets/img/sprite.svg#navigate_next"></use>
                 </svg>
+                <span class="usa-pagination__link-text">Next</span>
               </a>
             </li>
           {% endif %}

--- a/app/src/js/modules/data.js
+++ b/app/src/js/modules/data.js
@@ -12,17 +12,22 @@ export const baseurl = DOMPurify.sanitize(siteData.baseurl);
 
 export const projects = setProjectsData(parsedProjectsData)
 
-// export let filteredProjects = [...parsedProjectsData];
-
 export function setProjectsData(parsedData) {
     let projects = {};
     const orgCheckboxes = document.getElementById('organization-content').querySelectorAll('.usa-checkbox');
     const organizations = [...orgCheckboxes].map(checkbox => checkbox.textContent.trim());
-    
+
     organizations.forEach(org => {
-      projects[org] = getProjectsInOrg(parsedData, org);
-    })
-    return projects
+      projects[org] = [];
+    });
+    
+    parsedData.forEach(project => {
+      if(project.owner in projects) {
+        projects[project.owner].push(project)
+      }
+    });
+
+    return projects;
   }
 
   export function findObject(array, value) {

--- a/app/src/js/modules/events.js
+++ b/app/src/js/modules/events.js
@@ -1,5 +1,5 @@
 import { sortDirection, sortSelection, parsedProjectsData } from "./data";
-import { getFilteredProjects, setFilteredProjects, updateFilters, updateFilteredProjects } from "./filters";
+import { setFilteredProjects, updateFilters, updateFilteredProjects } from "./filters";
 import { sortCards } from "./sorting";
 import { renderPaginatedProjects } from "./rendering";
 
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", () => {
       );
       setFilteredProjects(newFilteredProjects)
       currentPage = 1
-      renderPaginatedProjects(getFilteredProjects());
+      renderPaginatedProjects();
     }
   })
 });

--- a/app/src/js/modules/filters.js
+++ b/app/src/js/modules/filters.js
@@ -119,6 +119,7 @@ export function updateFilters() {
     })
   })
 
+  addFilterButtonGroup(selectedFiltersObject);
   updateHeadingVisibility();
 }
 

--- a/app/src/js/modules/filters.js
+++ b/app/src/js/modules/filters.js
@@ -3,7 +3,8 @@ import { addGlobalEventListener, updateHeadingVisibility } from "./utilities";
 import { renderPaginatedProjects, renderPaginationControls } from "./rendering";
 import { sortCards } from "./sorting";
 
-
+let currentPage = 1
+const itemsPerPage = 10;
 let filteredProjects = [...parsedProjectsData];
 
 export function getFilteredProjects() {
@@ -13,9 +14,6 @@ export function getFilteredProjects() {
 export function setFilteredProjects(projects) {
   filteredProjects = projects;
 }
-
-let currentPage = 1
-const itemsPerPage = 10;
 
 export function updateFilteredProjects() {
   const selectedFiltersObject = {
@@ -140,7 +138,6 @@ export function checkFilterCriteria(card, selectedFiltersObject) {
 export function updatePagination() {
   const totalProjects = (filteredProjects || parsedProjectsData).length;
   const totalPages = Math.ceil(totalProjects / itemsPerPage);
-
   currentPage = Math.min(currentPage, totalPages || 1);
   renderPaginationControls(totalPages);
 }

--- a/app/src/js/modules/filters.js
+++ b/app/src/js/modules/filters.js
@@ -15,7 +15,7 @@ export function setFilteredProjects(projects) {
   filteredProjects = projects;
 }
 
-export function updateFilteredProjects() {
+function getSelectedFilters() {
   const selectedFiltersObject = {
     organization: [],
     maturityModelTier: [],
@@ -36,12 +36,18 @@ export function updateFilteredProjects() {
     selectedFiltersObject.projectType.push(checkbox.value);
   });
 
+  return selectedFiltersObject;
+}
+
+export function updateFilteredProjects() {
+  const selected = getSelectedFilters();
+ 
   const allProjects = Object.keys(projects).flatMap((org) => projects[org].map((project) => ({...project, org})))
   filteredProjects = allProjects.filter((project) => {
-    const matchesOrg = selectedFiltersObject.organization.length === 0 || selectedFiltersObject.organization.includes(project.org);
-    const matchesTier = selectedFiltersObject.maturityModelTier.length === 0 || selectedFiltersObject.maturityModelTier.includes("Tier" + project.maturityModelTier);
-    const matchesFisma = selectedFiltersObject.fismaLevel.length === 0 || selectedFiltersObject.fismaLevel.includes(project.fismaLevel);
-    const matchesType = selectedFiltersObject.projectType.length === 0 || selectedFiltersObject.projectType.includes(project.projectType);
+    const matchesOrg = selected.organization.length === 0 || selected.organization.includes(project.org);
+    const matchesTier = selected.maturityModelTier.length === 0 || selected.maturityModelTier.includes("Tier" + project.maturityModelTier);
+    const matchesFisma = selected.fismaLevel.length === 0 || selected.fismaLevel.includes(project.fismaLevel);
+    const matchesType = selected.projectType.length === 0 || selected.projectType.includes(project.projectType);
     return  matchesOrg && matchesTier && matchesFisma && matchesType;
   });
  
@@ -88,38 +94,20 @@ export function addFilterButtonGroup(selectedFiltersObject) {
 }
 
 export function updateFilters() {
-  const selectedFiltersObject = {
-    organization: [],
-    maturityModelTier: [],
-    fismaLevel: [],
-    projectType: []
-  }
+  const selected = getSelectedFilters();
 
-  document.querySelectorAll('input[name="org-filter"]:checked').forEach(checkbox => {
-    selectedFiltersObject.organization.push(checkbox.value);
-  });
-  document.querySelectorAll('input[name="tier-filter"]:checked').forEach(checkbox => {
-    selectedFiltersObject.maturityModelTier.push(checkbox.value);
-  });
-  document.querySelectorAll('input[name="fisma-level-filter"]:checked').forEach(checkbox => {
-    selectedFiltersObject.fismaLevel.push(checkbox.value);
-  });
-  document.querySelectorAll('input[name="project-type-filter"]:checked').forEach(checkbox => {
-    selectedFiltersObject.projectType.push(checkbox.value);
-  });
-
-  addFilterButtonGroup(selectedFiltersObject)
+  addFilterButtonGroup(selected)
   const projectSections = document.querySelectorAll(".project_section");
 
   projectSections.forEach((section) => {
     const projectCards = section.querySelectorAll(".project-card");
     
     projectCards.forEach((card) => {
-      checkFilterCriteria(card, selectedFiltersObject);
+      checkFilterCriteria(card, selected);
     })
   })
 
-  addFilterButtonGroup(selectedFiltersObject);
+  addFilterButtonGroup(selected);
   updateHeadingVisibility();
 }
 

--- a/app/src/js/modules/rendering.js
+++ b/app/src/js/modules/rendering.js
@@ -1,6 +1,6 @@
 import { reportHeadingTemplate, projectCardTemplate } from "../templates";
-import { templateDiv, parsedProjectsData, orgsData, siteData, findObject, baseurl, setProjectsData } from "./data";
-import { getFilteredProjects, updateFilters } from "./filters";
+import { templateDiv, parsedProjectsData, orgsData, siteData, findObject, baseurl } from "./data";
+import { getFilteredProjects } from "./filters";
 import { getPageRange, updateHeadingVisibility } from "./utilities";
 import DOMPurify from 'dompurify';
 
@@ -63,28 +63,28 @@ function renderProjectGroups(projects, groupByKey = 'org') {
           projectCards.appendChild(projectCard);
         });
   }
-  console.log({groupedByOrg})
 }
 
-export async function createProjectCards(projects = getFilteredProjects()) {
+export async function createProjectCards(projects) {
   await ensureReadyData();
   templateDiv.innerHTML = ''
-  
-  const allProjects = (projects || parsedProjectsData).map((project) => ({
-    ...project,
-    org: project.owner
-  }));
 
-  if(currentPage < 1 || currentPage > Math.ceil(allProjects.length / itemsPerPage)) {
+  const displayProjects = (projects || getFilteredProjects()).slice().sort((a, b) => a.owner.localeCompare(b.owner));
+
+  const allProjects = displayProjects.map((project) => ({
+    ...project,
+    org: project.owner || project.owner
+  }))
+
+  const totalPages = Math.ceil(allProjects.length / itemsPerPage);
+  if(currentPage < 1 || currentPage > totalPages) {
     currentPage = 1;
   }
   
   const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const paginatedProjects = allProjects.slice(startIndex, endIndex);
+  const paginatedProjects = allProjects.slice(startIndex, startIndex + itemsPerPage);
 
   renderProjectGroups(paginatedProjects);
-  updateFilters();
   updateHeadingVisibility();
   renderPaginationControls(allProjects.length);
 }

--- a/app/src/js/modules/sorting.js
+++ b/app/src/js/modules/sorting.js
@@ -1,14 +1,12 @@
-import { sortSelection, parsedProjectsData, filtersContainer } from "./data";
+import { sortSelection, filtersContainer } from "./data";
 import { addGlobalEventListener } from "./utilities";
-import { updateFilters, updateFilteredProjects, updatePagination } from "./filters";
+import { updateFilters, updateFilteredProjects, getFilteredProjects, setFilteredProjects } from "./filters";
 import { renderPaginatedProjects } from "./rendering";
-
-let filteredProjects = [...parsedProjectsData]
 
 export function sortCards(isDescending = false) {
   const selection = sortSelection.value;
 
-  let targetProjects = filteredProjects || parsedOrgsData
+  const targetProjects = getFilteredProjects();
 
   if(["maturity_model_tier", "stargazers_count", "forks_count"].includes(selection)) {
     sortByNumberAttribute(targetProjects, selection, isDescending);
@@ -16,8 +14,8 @@ export function sortCards(isDescending = false) {
     sortByStringAttribute(targetProjects, selection, isDescending);
   }
 
-  updatePagination();
-  renderPaginatedProjects(filteredProjects);
+  setFilteredProjects(targetProjects);
+  renderPaginatedProjects();
 }
 
 export function sortByNumberAttribute(data, attribute, isDescending) {

--- a/app/src/js/modules/ui.js
+++ b/app/src/js/modules/ui.js
@@ -1,0 +1,63 @@
+import { baseurl } from "./data";
+
+export function updateFilterMenuState() {
+    const filterButtons = document.querySelectorAll(".usa-accordion__button");
+    const isMobile = window.innerWidth < 768;
+
+    filterButtons.forEach((button) => {
+      const contentId = button.getAttribute("aria-controls");
+      const content = document.getElementById(contentId);
+      const icon = button.querySelector("svg use");
+
+      if(isMobile) {
+        button.setAttribute("aria-expanded", "false");
+        content.setAttribute("hidden", "true");
+        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
+      } else {
+        button.setAttribute("aria-expanded", "true");
+        content.removeAttribute("hidden");
+        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
+      }
+    });
+  }
+
+//   updateFilterMenuState()
+
+//   window.addEventListener("resize", updateFilterMenuState)
+
+//   document.querySelectorAll(".usa-accordion__button").forEach((button) => {
+//     button.addEventListener("click", () => {
+//       const expanded = button.getAttribute("aria-expanded");
+//       const content = document.getElementById(button.getAttribute("id"));
+//       const icon = button.querySelector("svg use");
+      
+//       if(expanded === 'false') {
+//         content.removeAttribute("hidden");
+//         icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
+//       } else {
+//         content.setAttribute("hidden", "true");
+//         icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
+//       }
+//     });
+//   });
+
+export function setupFilterMenuListeners() {
+    updateFilterMenuState()
+    window.addEventListener("resize", updateFilterMenuState)
+
+    document.querySelectorAll(".usa-accordion__button").forEach((button) => {
+        button.addEventListener("click", () => {
+            const expanded = button.getAttribute("aria-expanded");
+            const content = document.getElementById(button.getAttribute("id"));
+            const icon = button.querySelector("svg use");
+      
+            if(expanded === 'false') {
+                content.removeAttribute("hidden");
+                icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
+            } else {
+                content.setAttribute("hidden", "true");
+                icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
+            }
+        });
+    });
+}

--- a/app/src/js/modules/ui.js
+++ b/app/src/js/modules/ui.js
@@ -21,26 +21,6 @@ export function updateFilterMenuState() {
     });
   }
 
-//   updateFilterMenuState()
-
-//   window.addEventListener("resize", updateFilterMenuState)
-
-//   document.querySelectorAll(".usa-accordion__button").forEach((button) => {
-//     button.addEventListener("click", () => {
-//       const expanded = button.getAttribute("aria-expanded");
-//       const content = document.getElementById(button.getAttribute("id"));
-//       const icon = button.querySelector("svg use");
-      
-//       if(expanded === 'false') {
-//         content.removeAttribute("hidden");
-//         icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
-//       } else {
-//         content.setAttribute("hidden", "true");
-//         icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
-//       }
-//     });
-//   });
-
 export function setupFilterMenuListeners() {
     updateFilterMenuState()
     window.addEventListener("resize", updateFilterMenuState)

--- a/app/src/js/modules/utilities.js
+++ b/app/src/js/modules/utilities.js
@@ -1,4 +1,4 @@
-export function addGlobalEventListener(type, selector, callback, parent = document) {
+ export function addGlobalEventListener(type, selector, callback, parent = document) {
   parent.addEventListener(type, e => {
     if (e.target.matches(selector)) {
       callback(e);

--- a/app/src/js/projects.js
+++ b/app/src/js/projects.js
@@ -1,12 +1,18 @@
 import { createProjectCards } from "./modules/rendering";
+import { updateFilteredProjects } from "./modules/filters";
 import { setupEventListeners } from './modules/events';
 import { baseurl } from './modules/data';
 
-createProjectCards();
-setupEventListeners()
+// createProjectCards();
+// setupEventListeners();
 
 // Controls filter menus open/closed state
 document.addEventListener("DOMContentLoaded", () => {
+  setTimeout(() => {
+    createProjectCards();
+    setupEventListeners();
+  }, 50);
+
   function updateFilterMenuState() {
     const filterButtons = document.querySelectorAll(".usa-accordion__button");
     const isMobile = window.innerWidth < 768;
@@ -37,7 +43,6 @@ document.addEventListener("DOMContentLoaded", () => {
       const expanded = button.getAttribute("aria-expanded");
       const content = document.getElementById(button.getAttribute("id"));
       const icon = button.querySelector("svg use");
-      console.log("2", baseurl)
       
       if(expanded === 'false') {
         content.removeAttribute("hidden");

--- a/app/src/js/projects.js
+++ b/app/src/js/projects.js
@@ -1,56 +1,14 @@
 import { createProjectCards } from "./modules/rendering";
 import { updateFilteredProjects } from "./modules/filters";
 import { setupEventListeners } from './modules/events';
-import { baseurl } from './modules/data';
+import { setupFilterMenuListeners } from "./modules/ui";
 
-// createProjectCards();
-// setupEventListeners();
-
-// Controls filter menus open/closed state
 document.addEventListener("DOMContentLoaded", () => {
-  setTimeout(() => {
-    createProjectCards();
+  setTimeout(async () => {
+    await createProjectCards();
+    updateFilteredProjects();
     setupEventListeners();
   }, 50);
 
-  function updateFilterMenuState() {
-    const filterButtons = document.querySelectorAll(".usa-accordion__button");
-    const isMobile = window.innerWidth < 768;
-
-    filterButtons.forEach((button) => {
-      const contentId = button.getAttribute("aria-controls");
-      const content = document.getElementById(contentId);
-      const icon = button.querySelector("svg use");
-
-      if(isMobile) {
-        button.setAttribute("aria-expanded", "false");
-        content.setAttribute("hidden", "true");
-        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
-      } else {
-        button.setAttribute("aria-expanded", "true");
-        content.removeAttribute("hidden");
-        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
-      }
-    });
-  }
-
-  updateFilterMenuState()
-
-  window.addEventListener("resize", updateFilterMenuState)
-
-  document.querySelectorAll(".usa-accordion__button").forEach((button) => {
-    button.addEventListener("click", () => {
-      const expanded = button.getAttribute("aria-expanded");
-      const content = document.getElementById(button.getAttribute("id"));
-      const icon = button.querySelector("svg use");
-      
-      if(expanded === 'false') {
-        content.removeAttribute("hidden");
-        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_less`);
-      } else {
-        content.setAttribute("hidden", "true");
-        icon.setAttribute("href", `${baseurl}/assets/img/sprite.svg#expand_more`);
-      }
-    });
-  });
+  setupFilterMenuListeners();
 });


### PR DESCRIPTION
## module-name: Refactor filter functionality

## Problem
- Initialization Issues:
  - Project cards load randomly on first render, instead of being organized by orgs.
  - Filter state does not properly initialize on page load
- Code duplication:
  -  Filter logic repeats across multiple functions
  - UI state management is mixed with core filtering logic
- Maintainability:
  - Adding new filter types requires changes in multiple places
  - Filter configuration is hardcoded in several places

## Solution
- Code Architecture Changes:
  - Create centralized filter checks
  - Implement shared utility functions (`getSelectedFilters` etc.)
  - Separate UI logic from core filtering logic
- Initialization Fixes:
  - Add proper async initialization
  - Ensure consistent org grouping on first render and with filters and search
- Code organization:
  -  Extract menu logic into new `ui.js` module
  - Simplify main project initialization flow

## Result
- Behavioral Improvements:
  - Projects now consistently group by organization
  - Filter state applies immediately without requiring pagination interaction
- Code:
  - Reduced duplication
  - Clear separation of concerns between modules
  - Single source of truth for filter configuration

Some important notes regarding the summary line:
- Backwards Compatibility: All existing functionality remains unchanged
- Foundation set for CSS refactor

## Test Plan
- Verified projects group by org
- Check for correct initialization
- Test each filters
- Verify clear filter functionality
- Verify page reset on changes
- Test in prod

## Next Steps
- CSS refactor
- Begin backlog metrics tickets
- Implement testing (unit and UI)
